### PR TITLE
Fix Photon Efficiencies

### DIFF
--- a/Tools/MakePlots.C
+++ b/Tools/MakePlots.C
@@ -269,13 +269,13 @@ int main(int argc, char* argv[])
     std::string label_phopt = "p_{T}^{#gamma} [GeV]";
     std::string label_metg = "p_{T}^{#gamma (miss)} [GeV]";
     std::string label_ptcut_single = "ptcut & gen";
-    std::string label_acc_single = "acc & gen";
-    std::string label_reco_single = "reco & acc";
-    std::string label_iso_single = "iso & reco";
+    std::string label_acc_single = "acc & all";
+    std::string label_matched_single = "matched & acc";
+    std::string label_iso_single = "iso & matched";
     std::string label_ptcut_ratio = "ptcut/gen";
-    std::string label_acc_ratio = "acc/gen";
-    std::string label_reco_ratio = "reco/acc";
-    std::string label_iso_ratio = "iso/reco";
+    std::string label_acc_ratio = "acc/all";
+    std::string label_matched_ratio = "matched/acc";
+    std::string label_iso_ratio = "iso/matched";
 
     vector<Plotter::HistSummary> vh;
 
@@ -360,17 +360,17 @@ int main(int argc, char* argv[])
     auto makePDCMuIso_ratio    = [&](const std::string& var, const std::string& style) {return Plotter::DataCollection(style, {{"genMatchIsoMuInAcc("+var+")",   makePDSMu("#mu iso over reco")}, {"genMatchMuInAcc("+var+")",   makePDSMu("#mu iso over reco")}}); };
     // photons
     // only passing pt cut: ratio = gammaLVecGenPtCut / gammaLVecGen
-    auto makePDCPhotonPtCut_single  = [&](const std::string& var, const std::string& style) {return Plotter::DataCollection(style, {{"gammaLVecGenAcc("+var+")", makePDSPhoton("acc")},                {"gammaLVecGenPtCut("+var+")", makePDSPhoton("genPtCut")}}); };
-    auto makePDCPhotonPtCut_ratio   = [&](const std::string& var, const std::string& style) {return Plotter::DataCollection(style, {{"gammaLVecGenAcc("+var+")", makePDSPhoton("acc over genPtCut")},  {"gammaLVecGenPtCut("+var+")", makePDSPhoton("acc over genPtCut")}}); };
+    auto makePDCPhotonPtCut_single  = [&](const std::string& var, const std::string& style) {return Plotter::DataCollection(style, {{"gammaLVecGenAcc("+var+")", makePDSPhoton("genAcc")},                {"gammaLVecGenPtCut("+var+")", makePDSPhoton("genPtCut")}}); };
+    auto makePDCPhotonPtCut_ratio   = [&](const std::string& var, const std::string& style) {return Plotter::DataCollection(style, {{"gammaLVecGenAcc("+var+")", makePDSPhoton("genAcc over genPtCut")},  {"gammaLVecGenPtCut("+var+")", makePDSPhoton("genAcc over genPtCut")}}); };
     // acceptance = gammaLVecGenAcc / gammaLVecGen (acc / gen)
-    auto makePDCPhotonAcc_single  = [&](const std::string& var, const std::string& style) {return Plotter::DataCollection(style, {{"gammaLVecGenAcc("+var+")", makePDSPhoton("acc")},           {"gammaLVecGen("+var+")", makePDSPhoton("gen")}}); };
-    auto makePDCPhotonAcc_ratio   = [&](const std::string& var, const std::string& style) {return Plotter::DataCollection(style, {{"gammaLVecGenAcc("+var+")", makePDSPhoton("acc over gen")},  {"gammaLVecGen("+var+")", makePDSPhoton("acc over gen")}}); };
+    auto makePDCPhotonAcc_single  = [&](const std::string& var, const std::string& style) {return Plotter::DataCollection(style, {{"gammaLVecRecoEta("+var+")", makePDSPhoton("recoEta")},           {"gammaLVec("+var+")", makePDSPhoton("reco")}}); };
+    auto makePDCPhotonAcc_ratio   = [&](const std::string& var, const std::string& style) {return Plotter::DataCollection(style, {{"gammaLVecRecoEta("+var+")", makePDSPhoton("recoEta over reco")}, {"gammaLVec("+var+")", makePDSPhoton("recoEta over reco")}}); };
     // reco efficiency = gammaLVecGenRecoMatched / gammaLVecGenAcc (reco / acc)
-    auto makePDCPhotonReco_single = [&](const std::string& var, const std::string& style) {return Plotter::DataCollection(style, {{"gammaLVecGenRecoMatched("+var+")", makePDSPhoton("reco")},             {"gammaLVecGenAcc("+var+")", makePDSPhoton("acc")}}); };
-    auto makePDCPhotonReco_ratio  = [&](const std::string& var, const std::string& style) {return Plotter::DataCollection(style, {{"gammaLVecGenRecoMatched("+var+")", makePDSPhoton("reco over acc")},    {"gammaLVecGenAcc("+var+")", makePDSPhoton("reco over acc")}}); };
+    auto makePDCPhotonReco_single = [&](const std::string& var, const std::string& style) {return Plotter::DataCollection(style, {{"gammaLVecRecoEtaPtMatched("+var+")", makePDSPhoton("reco")},             {"gammaLVecRecoEtaPt("+var+")", makePDSPhoton("acc")}}); };
+    auto makePDCPhotonReco_ratio  = [&](const std::string& var, const std::string& style) {return Plotter::DataCollection(style, {{"gammaLVecRecoEtaPtMatched("+var+")", makePDSPhoton("reco over acc")},    {"gammaLVecRecoEtaPt("+var+")", makePDSPhoton("reco over acc")}}); };
     // iso efficiency = gammaLVecGenIso / gammaLVecGenRecoMatched (iso / reco)
-    auto makePDCPhotonIso_single  = [&](const std::string& var, const std::string& style) {return Plotter::DataCollection(style, {{"gammaLVecGenIso("+var+")", makePDSPhoton("iso")},           {"gammaLVecGenRecoMatched("+var+")", makePDSPhoton("reco")}}); };
-    auto makePDCPhotonIso_ratio   = [&](const std::string& var, const std::string& style) {return Plotter::DataCollection(style, {{"gammaLVecGenIso("+var+")", makePDSPhoton("iso over reco")}, {"gammaLVecGenRecoMatched("+var+")", makePDSPhoton("iso over reco")}}); };
+    auto makePDCPhotonIso_single  = [&](const std::string& var, const std::string& style) {return Plotter::DataCollection(style, {{"gammaLVecRecoIso("+var+")", makePDSPhoton("iso")},           {"gammaLVecRecoEtaPtMatched("+var+")", makePDSPhoton("reco")}}); };
+    auto makePDCPhotonIso_ratio   = [&](const std::string& var, const std::string& style) {return Plotter::DataCollection(style, {{"gammaLVecRecoIso("+var+")", makePDSPhoton("iso over reco")}, {"gammaLVecRecoEtaPtMatched("+var+")", makePDSPhoton("iso over reco")}}); };
     
 
     // photons gen: gammaLVecGen
@@ -538,16 +538,16 @@ int main(int argc, char* argv[])
     plotParamsElec.push_back({"Elec", "Acc", "Eta",    makePDCElecAcc_ratio("eta","ratio"),   "ratio",  nBins, minEta, maxEta, false, false, label_ElecEta, label_acc_ratio, true});
     plotParamsElec.push_back({"Elec", "Acc", "Phi",    makePDCElecAcc_ratio("phi","ratio"),   "ratio",  nBins, minPhi, maxPhi, false, false, label_ElecPhi, label_acc_ratio, true});
     // Reco
-    plotParamsElec.push_back({"Elec", "Reco", "Pt",     makePDCElecReco_single("pt","single"),  "single", nBins, minPt, maxPt, true, false, label_ElecPt, label_reco_single, true});
-    plotParamsElec.push_back({"Elec", "Reco", "Energy", makePDCElecReco_single("E","single"),   "single", nBins, minEnergy, maxEnergy, true, false, label_ElecEnergy, label_reco_single, true});
-    plotParamsElec.push_back({"Elec", "Reco", "Mass",   makePDCElecReco_single("M","single"),   "single", nBins, minMassElec, maxMassElec, false, false, label_ElecMass, label_reco_single, true});
-    plotParamsElec.push_back({"Elec", "Reco", "Eta",    makePDCElecReco_single("eta","single"), "single", nBins, minEta, maxEta, false, false, label_ElecEta, label_reco_single, true});
-    plotParamsElec.push_back({"Elec", "Reco", "Phi",    makePDCElecReco_single("phi","single"), "single", nBins, minPhi, maxPhi, false, false, label_ElecPhi, label_reco_single, true});
-    plotParamsElec.push_back({"Elec", "Reco", "Pt",     makePDCElecReco_ratio("pt","ratio"),    "ratio",  nBins, minPt, maxPt, false, false, label_ElecPt, label_reco_ratio, true});
-    plotParamsElec.push_back({"Elec", "Reco", "Energy", makePDCElecReco_ratio("E","ratio"),     "ratio",  nBins, minEnergy, maxEnergy, false, false, label_ElecEnergy, label_reco_ratio, true});
-    plotParamsElec.push_back({"Elec", "Reco", "Mass",   makePDCElecReco_ratio("M","ratio"),     "ratio",  nBins, minMassElec, maxMassElec, false, false, label_ElecMass, label_reco_ratio, true});
-    plotParamsElec.push_back({"Elec", "Reco", "Eta",    makePDCElecReco_ratio("eta","ratio"),   "ratio",  nBins, minEta, maxEta, false, false, label_ElecEta, label_reco_ratio, true});
-    plotParamsElec.push_back({"Elec", "Reco", "Phi",    makePDCElecReco_ratio("phi","ratio"),   "ratio",  nBins, minPhi, maxPhi, false, false, label_ElecPhi, label_reco_ratio, true});
+    plotParamsElec.push_back({"Elec", "Reco", "Pt",     makePDCElecReco_single("pt","single"),  "single", nBins, minPt, maxPt, true, false, label_ElecPt, label_matched_single, true});
+    plotParamsElec.push_back({"Elec", "Reco", "Energy", makePDCElecReco_single("E","single"),   "single", nBins, minEnergy, maxEnergy, true, false, label_ElecEnergy, label_matched_single, true});
+    plotParamsElec.push_back({"Elec", "Reco", "Mass",   makePDCElecReco_single("M","single"),   "single", nBins, minMassElec, maxMassElec, false, false, label_ElecMass, label_matched_single, true});
+    plotParamsElec.push_back({"Elec", "Reco", "Eta",    makePDCElecReco_single("eta","single"), "single", nBins, minEta, maxEta, false, false, label_ElecEta, label_matched_single, true});
+    plotParamsElec.push_back({"Elec", "Reco", "Phi",    makePDCElecReco_single("phi","single"), "single", nBins, minPhi, maxPhi, false, false, label_ElecPhi, label_matched_single, true});
+    plotParamsElec.push_back({"Elec", "Reco", "Pt",     makePDCElecReco_ratio("pt","ratio"),    "ratio",  nBins, minPt, maxPt, false, false, label_ElecPt, label_matched_ratio, true});
+    plotParamsElec.push_back({"Elec", "Reco", "Energy", makePDCElecReco_ratio("E","ratio"),     "ratio",  nBins, minEnergy, maxEnergy, false, false, label_ElecEnergy, label_matched_ratio, true});
+    plotParamsElec.push_back({"Elec", "Reco", "Mass",   makePDCElecReco_ratio("M","ratio"),     "ratio",  nBins, minMassElec, maxMassElec, false, false, label_ElecMass, label_matched_ratio, true});
+    plotParamsElec.push_back({"Elec", "Reco", "Eta",    makePDCElecReco_ratio("eta","ratio"),   "ratio",  nBins, minEta, maxEta, false, false, label_ElecEta, label_matched_ratio, true});
+    plotParamsElec.push_back({"Elec", "Reco", "Phi",    makePDCElecReco_ratio("phi","ratio"),   "ratio",  nBins, minPhi, maxPhi, false, false, label_ElecPhi, label_matched_ratio, true});
     // Iso
     plotParamsElec.push_back({"Elec", "Iso", "Pt",     makePDCElecIso_single("pt","single"),  "single", nBins, minPt, maxPt, true, false, label_ElecPt, label_iso_single, true});
     plotParamsElec.push_back({"Elec", "Iso", "Energy", makePDCElecIso_single("E","single"),   "single", nBins, minEnergy, maxEnergy, true, false, label_ElecEnergy, label_iso_single, true});
@@ -578,16 +578,16 @@ int main(int argc, char* argv[])
     plotParamsMu.push_back({"Mu", "Acc", "Eta",    makePDCMuAcc_ratio("eta","ratio"),  "ratio",  nBins, minEta, maxEta, false, false, label_MuEta, label_acc_ratio, true});
     plotParamsMu.push_back({"Mu", "Acc", "Phi",    makePDCMuAcc_ratio("phi","ratio"),  "ratio",  nBins, minPhi, maxPhi, false, false, label_MuPhi, label_acc_ratio, true});
     // Reco
-    plotParamsMu.push_back({"Mu", "Reco", "Pt",     makePDCMuReco_single("pt","single"),  "single", nBins, minPt, maxPt, true, false, label_MuPt, label_reco_single, true});
-    plotParamsMu.push_back({"Mu", "Reco", "Energy", makePDCMuReco_single("E","single"),   "single", nBins, minEnergy, maxEnergy, true, false, label_MuEnergy, label_reco_single, true});
-    plotParamsMu.push_back({"Mu", "Reco", "Mass",   makePDCMuReco_single("M","single"),   "single", nBins, minMassMu, maxMassMu, false, false, label_MuMass, label_reco_single, true});
-    plotParamsMu.push_back({"Mu", "Reco", "Eta",    makePDCMuReco_single("eta","single"), "single", nBins, minEta, maxEta, false, false, label_MuEta, label_reco_single, true});
-    plotParamsMu.push_back({"Mu", "Reco", "Phi",    makePDCMuReco_single("phi","single"), "single", nBins, minPhi, maxPhi, false, false, label_MuPhi, label_reco_single, true});
-    plotParamsMu.push_back({"Mu", "Reco", "Pt",     makePDCMuReco_ratio("pt","ratio"),   "ratio",  nBins, minPt, maxPt, false, false, label_MuPt, label_reco_ratio, true});
-    plotParamsMu.push_back({"Mu", "Reco", "Energy", makePDCMuReco_ratio("E","ratio"),    "ratio",  nBins, minEnergy, maxEnergy, false, false, label_MuEnergy, label_reco_ratio, true});
-    plotParamsMu.push_back({"Mu", "Reco", "Mass",   makePDCMuReco_ratio("M","ratio"),    "ratio",  nBins, minMassMu, maxMassMu, false, false, label_MuMass, label_reco_ratio, true});
-    plotParamsMu.push_back({"Mu", "Reco", "Eta",    makePDCMuReco_ratio("eta","ratio"),  "ratio",  nBins, minEta, maxEta, false, false, label_MuEta, label_reco_ratio, true});
-    plotParamsMu.push_back({"Mu", "Reco", "Phi",    makePDCMuReco_ratio("phi","ratio"),  "ratio",  nBins, minPhi, maxPhi, false, false, label_MuPhi, label_reco_ratio, true});
+    plotParamsMu.push_back({"Mu", "Reco", "Pt",     makePDCMuReco_single("pt","single"),  "single", nBins, minPt, maxPt, true, false, label_MuPt, label_matched_single, true});
+    plotParamsMu.push_back({"Mu", "Reco", "Energy", makePDCMuReco_single("E","single"),   "single", nBins, minEnergy, maxEnergy, true, false, label_MuEnergy, label_matched_single, true});
+    plotParamsMu.push_back({"Mu", "Reco", "Mass",   makePDCMuReco_single("M","single"),   "single", nBins, minMassMu, maxMassMu, false, false, label_MuMass, label_matched_single, true});
+    plotParamsMu.push_back({"Mu", "Reco", "Eta",    makePDCMuReco_single("eta","single"), "single", nBins, minEta, maxEta, false, false, label_MuEta, label_matched_single, true});
+    plotParamsMu.push_back({"Mu", "Reco", "Phi",    makePDCMuReco_single("phi","single"), "single", nBins, minPhi, maxPhi, false, false, label_MuPhi, label_matched_single, true});
+    plotParamsMu.push_back({"Mu", "Reco", "Pt",     makePDCMuReco_ratio("pt","ratio"),   "ratio",  nBins, minPt, maxPt, false, false, label_MuPt, label_matched_ratio, true});
+    plotParamsMu.push_back({"Mu", "Reco", "Energy", makePDCMuReco_ratio("E","ratio"),    "ratio",  nBins, minEnergy, maxEnergy, false, false, label_MuEnergy, label_matched_ratio, true});
+    plotParamsMu.push_back({"Mu", "Reco", "Mass",   makePDCMuReco_ratio("M","ratio"),    "ratio",  nBins, minMassMu, maxMassMu, false, false, label_MuMass, label_matched_ratio, true});
+    plotParamsMu.push_back({"Mu", "Reco", "Eta",    makePDCMuReco_ratio("eta","ratio"),  "ratio",  nBins, minEta, maxEta, false, false, label_MuEta, label_matched_ratio, true});
+    plotParamsMu.push_back({"Mu", "Reco", "Phi",    makePDCMuReco_ratio("phi","ratio"),  "ratio",  nBins, minPhi, maxPhi, false, false, label_MuPhi, label_matched_ratio, true});
     // Iso
     plotParamsMu.push_back({"Mu", "Iso", "Pt",     makePDCMuIso_single("pt","single"),  "single", nBins, minPt, maxPt, true, false, label_MuPt, label_iso_single, true});
     plotParamsMu.push_back({"Mu", "Iso", "Energy", makePDCMuIso_single("E","single"),   "single", nBins, minEnergy, maxEnergy, true, false, label_MuEnergy, label_iso_single, true});
@@ -629,16 +629,16 @@ int main(int argc, char* argv[])
     plotParamsPhoton.push_back({"Photon", "Acc", "Eta",    makePDCPhotonAcc_ratio("eta","ratio"),   "ratio",  nBins, minEta, maxEta, false, false, label_PhotonEta, label_acc_ratio, true});
     plotParamsPhoton.push_back({"Photon", "Acc", "Phi",    makePDCPhotonAcc_ratio("phi","ratio"),   "ratio",  nBins, minPhi, maxPhi, false, false, label_PhotonPhi, label_acc_ratio, true});
     // Reco
-    plotParamsPhoton.push_back({"Photon", "Reco", "Pt",     makePDCPhotonReco_single("pt","single"),  "single", nBins, minPt, maxPt, true, false, label_PhotonPt, label_reco_single, true});
-    plotParamsPhoton.push_back({"Photon", "Reco", "Energy", makePDCPhotonReco_single("E","single"),   "single", nBins, minEnergy, maxEnergy, true, false, label_PhotonEnergy, label_reco_single, true});
-    plotParamsPhoton.push_back({"Photon", "Reco", "Mass",   makePDCPhotonReco_single("M","single"),   "single", nBins, minMassPhoton, maxMassPhoton, false, false, label_PhotonMass, label_reco_single, true});
-    plotParamsPhoton.push_back({"Photon", "Reco", "Eta",    makePDCPhotonReco_single("eta","single"), "single", nBins, minEta, maxEta, false, false, label_PhotonEta, label_reco_single, true});
-    plotParamsPhoton.push_back({"Photon", "Reco", "Phi",    makePDCPhotonReco_single("phi","single"), "single", nBins, minPhi, maxPhi, false, false, label_PhotonPhi, label_reco_single, true});
-    plotParamsPhoton.push_back({"Photon", "Reco", "Pt",     makePDCPhotonReco_ratio("pt","ratio"),    "ratio",  nBins, minPt, maxPt, false, false, label_PhotonPt, label_reco_ratio, true});
-    plotParamsPhoton.push_back({"Photon", "Reco", "Energy", makePDCPhotonReco_ratio("E","ratio"),     "ratio",  nBins, minEnergy, maxEnergy, false, false, label_PhotonEnergy, label_reco_ratio, true});
-    plotParamsPhoton.push_back({"Photon", "Reco", "Mass",   makePDCPhotonReco_ratio("M","ratio"),     "ratio",  nBins, minMassPhoton, maxMassPhoton, false, false, label_PhotonMass, label_reco_ratio, true});
-    plotParamsPhoton.push_back({"Photon", "Reco", "Eta",    makePDCPhotonReco_ratio("eta","ratio"),   "ratio",  nBins, minEta, maxEta, false, false, label_PhotonEta, label_reco_ratio, true});
-    plotParamsPhoton.push_back({"Photon", "Reco", "Phi",    makePDCPhotonReco_ratio("phi","ratio"),   "ratio",  nBins, minPhi, maxPhi, false, false, label_PhotonPhi, label_reco_ratio, true});
+    plotParamsPhoton.push_back({"Photon", "Reco", "Pt",     makePDCPhotonReco_single("pt","single"),  "single", nBins, minPt, maxPt, true, false, label_PhotonPt, label_matched_single, true});
+    plotParamsPhoton.push_back({"Photon", "Reco", "Energy", makePDCPhotonReco_single("E","single"),   "single", nBins, minEnergy, maxEnergy, true, false, label_PhotonEnergy, label_matched_single, true});
+    plotParamsPhoton.push_back({"Photon", "Reco", "Mass",   makePDCPhotonReco_single("M","single"),   "single", nBins, minMassPhoton, maxMassPhoton, false, false, label_PhotonMass, label_matched_single, true});
+    plotParamsPhoton.push_back({"Photon", "Reco", "Eta",    makePDCPhotonReco_single("eta","single"), "single", nBins, minEta, maxEta, false, false, label_PhotonEta, label_matched_single, true});
+    plotParamsPhoton.push_back({"Photon", "Reco", "Phi",    makePDCPhotonReco_single("phi","single"), "single", nBins, minPhi, maxPhi, false, false, label_PhotonPhi, label_matched_single, true});
+    plotParamsPhoton.push_back({"Photon", "Reco", "Pt",     makePDCPhotonReco_ratio("pt","ratio"),    "ratio",  nBins, minPt, maxPt, false, false, label_PhotonPt, label_matched_ratio, true});
+    plotParamsPhoton.push_back({"Photon", "Reco", "Energy", makePDCPhotonReco_ratio("E","ratio"),     "ratio",  nBins, minEnergy, maxEnergy, false, false, label_PhotonEnergy, label_matched_ratio, true});
+    plotParamsPhoton.push_back({"Photon", "Reco", "Mass",   makePDCPhotonReco_ratio("M","ratio"),     "ratio",  nBins, minMassPhoton, maxMassPhoton, false, false, label_PhotonMass, label_matched_ratio, true});
+    plotParamsPhoton.push_back({"Photon", "Reco", "Eta",    makePDCPhotonReco_ratio("eta","ratio"),   "ratio",  nBins, minEta, maxEta, false, false, label_PhotonEta, label_matched_ratio, true});
+    plotParamsPhoton.push_back({"Photon", "Reco", "Phi",    makePDCPhotonReco_ratio("phi","ratio"),   "ratio",  nBins, minPhi, maxPhi, false, false, label_PhotonPhi, label_matched_ratio, true});
     // Iso
     plotParamsPhoton.push_back({"Photon", "Iso", "Pt",     makePDCPhotonIso_single("pt","single"),  "single", nBins, minPt, maxPt, true, false, label_PhotonPt, label_iso_single, true});
     plotParamsPhoton.push_back({"Photon", "Iso", "Energy", makePDCPhotonIso_single("E","single"),   "single", nBins, minEnergy, maxEnergy, true, false, label_PhotonEnergy, label_iso_single, true});

--- a/Tools/MakePlots.C
+++ b/Tools/MakePlots.C
@@ -379,15 +379,27 @@ int main(int argc, char* argv[])
     //auto makePDCPhotonPtCut_single  = [&](const std::string& var, const std::string& style) {return Plotter::DataCollection(style, {{"gammaLVecGenEtaPt("+var+")", makePDSPhoton("genEtaPt")},                {"gammaLVecGenPt("+var+")", makePDSPhoton("genPt")}}); };
     //auto makePDCPhotonPtCut_ratio   = [&](const std::string& var, const std::string& style) {return Plotter::DataCollection(style, {{"gammaLVecGenEtaPt("+var+")", makePDSPhoton("genEtaPt over genPt")},  {"gammaLVecGenPt("+var+")", makePDSPhoton("genEtaPt over genPt")}}); };
     // Tag must be Gen or Reco
-    // acceptance = gammaLVecTagEtaPt / gammaLVecTag (acc / gen)
+    // acceptance = gammaLVecTagEtaPt / gammaLVecTag (acc / tag)
     auto makePDCPhotonAcc_single   = [&](const std::string& tag, const std::string& var, const std::string& style) {return Plotter::DataCollection(style, {{"gammaLVec"+tag+"Eta("+var+")", makePDSPhoton(tag+"Eta")},           {"gammaLVec"+tag+"("+var+")", makePDSPhoton(tag)}}); };
     auto makePDCPhotonAcc_ratio    = [&](const std::string& tag, const std::string& var, const std::string& style) {return Plotter::DataCollection(style, {{"gammaLVec"+tag+"Eta("+var+")", makePDSPhoton(tag+"Eta over "+tag)}, {"gammaLVec"+tag+"("+var+")", makePDSPhoton(tag+"Eta over "+tag)}}); };
-    // match efficiency = gammaLVecTagMatched / gammaLVecTagEtaPt (match / acc)
-    auto makePDCPhotonMatch_single = [&](const std::string& tag, const std::string& var, const std::string& style) {return Plotter::DataCollection(style, {{"gammaLVec"+tag+"EtaPtMatched("+var+")", makePDSPhoton(tag+"EtaPtMatched")},                   {"gammaLVec"+tag+"EtaPt("+var+")", makePDSPhoton(tag+"EtaPt")}}); };
-    auto makePDCPhotonMatch_ratio  = [&](const std::string& tag, const std::string& var, const std::string& style) {return Plotter::DataCollection(style, {{"gammaLVec"+tag+"EtaPtMatched("+var+")", makePDSPhoton(tag+"EtaPtMatched over "+tag+"EtaPt")}, {"gammaLVec"+tag+"EtaPt("+var+")", makePDSPhoton(tag+"EtaPtMatched over "+tag+"EtaPt")}}); };
-    // iso efficiency = gammaLVecTagIso / gammaLVecTagMatched (iso / match)
-    auto makePDCPhotonIso_single   = [&](const std::string& tag, const std::string& var, const std::string& style) {return Plotter::DataCollection(style, {{"gammaLVec"+tag+"Iso("+var+")", makePDSPhoton(tag+"Iso")},                          {"gammaLVec"+tag+"EtaPtMatched("+var+")", makePDSPhoton(tag+"EtaPtMatched")}}); };
-    auto makePDCPhotonIso_ratio    = [&](const std::string& tag, const std::string& var, const std::string& style) {return Plotter::DataCollection(style, {{"gammaLVec"+tag+"Iso("+var+")", makePDSPhoton(tag+"Iso over "+tag+"EtaPtMatched")}, {"gammaLVec"+tag+"EtaPtMatched("+var+")", makePDSPhoton(tag+"Iso over "+tag+"EtaPtMatched")}}); };
+    // iso efficiency = gammaLVecTagIso / gammaLVecTagEtaPt (iso / acc)
+    // iso is only for reco!
+    auto makePDCPhotonIso_single   = [&](const std::string& tag, const std::string& var, const std::string& style) {return Plotter::DataCollection(style, {{"gammaLVec"+tag+"Iso("+var+")", makePDSPhoton(tag+"Iso")},                   {"gammaLVec"+tag+"EtaPt("+var+")", makePDSPhoton(tag+"EtaPt")}}); };
+    auto makePDCPhotonIso_ratio    = [&](const std::string& tag, const std::string& var, const std::string& style) {return Plotter::DataCollection(style, {{"gammaLVec"+tag+"Iso("+var+")", makePDSPhoton(tag+"Iso over "+tag+"EtaPt")}, {"gammaLVec"+tag+"EtaPt("+var+")", makePDSPhoton(tag+"Iso over "+tag+"EtaPt")}}); };
+    // Gen matched to Reco efficiency = gammaLVecGenMatched / gammaLVecGenEtaPt  (match / acc)
+    // Reco matched to Gen efficiency = gammaLVecRecoMatched / gammaLVecRecoIso  (match / iso)
+    auto makePDCPhotonMatch_single = [&](const std::string& tag, const std::string& var, const std::string& style) 
+    {
+        if (tag.compare("Gen") == 0)    return Plotter::DataCollection(style, {{"gammaLVec"+tag+"EtaPtMatched("+var+")", makePDSPhoton(tag+"EtaPtMatched")}, {"gammaLVec"+tag+"EtaPt("+var+")", makePDSPhoton(tag+"EtaPt")}}); 
+        if (tag.compare("Reco") == 0)   return Plotter::DataCollection(style, {{"gammaLVec"+tag+"EtaPtMatched("+var+")", makePDSPhoton(tag+"EtaPtMatched")}, {"gammaLVec"+tag+"Iso("+var+")", makePDSPhoton(tag+"Iso")}});
+        printf("ERROR: Tag must be Gen or Reco for Photon matching.\n");
+    };
+    auto makePDCPhotonMatch_ratio  = [&](const std::string& tag, const std::string& var, const std::string& style)
+    {
+        if (tag.compare("Gen") == 0)    return Plotter::DataCollection(style, {{"gammaLVec"+tag+"EtaPtMatched("+var+")", makePDSPhoton(tag+"EtaPtMatched over "+tag+"EtaPt")}, {"gammaLVec"+tag+"EtaPt("+var+")", makePDSPhoton(tag+"EtaPtMatched over "+tag+"EtaPt")}}); 
+        if (tag.compare("Reco") == 0)   return Plotter::DataCollection(style, {{"gammaLVec"+tag+"EtaPtMatched("+var+")", makePDSPhoton(tag+"EtaPtMatched over "+tag+"Iso")},   {"gammaLVec"+tag+"Iso("+var+")", makePDSPhoton(tag+"EtaPtMatched over "+tag+"Iso")}}); 
+        printf("ERROR: Tag must be Gen or Reco for Photon matching.\n");
+    };
     
 
     // photons gen: gammaLVecGen
@@ -650,17 +662,6 @@ int main(int argc, char* argv[])
       plotParamsPhoton.push_back({"Photon", tag+"Acc", "Mass",   makePDCPhotonAcc_ratio(tag, "M","ratio"),     "ratio",  nBins, minMassPhoton, maxMassPhoton, false, false, label_PhotonMass,   label_map[tag+"Acc_ratio"], true});
       plotParamsPhoton.push_back({"Photon", tag+"Acc", "Eta",    makePDCPhotonAcc_ratio(tag, "eta","ratio"),   "ratio",  nBins, minEta, maxEta,               false, false, label_PhotonEta,    label_map[tag+"Acc_ratio"], true});
       plotParamsPhoton.push_back({"Photon", tag+"Acc", "Phi",    makePDCPhotonAcc_ratio(tag, "phi","ratio"),   "ratio",  nBins, minPhi, maxPhi,               false, false, label_PhotonPhi,    label_map[tag+"Acc_ratio"], true});
-      // Match
-      plotParamsPhoton.push_back({"Photon", tag+"Match", "Pt",     makePDCPhotonMatch_single(tag, "pt","single"),  "single", nBins, minPt, maxPt,                 true, false,  label_PhotonPt,     label_map[tag+"Match_single"], true});
-      plotParamsPhoton.push_back({"Photon", tag+"Match", "Energy", makePDCPhotonMatch_single(tag, "E","single"),   "single", nBins, minEnergy, maxEnergy,         true, false,  label_PhotonEnergy, label_map[tag+"Match_single"], true});
-      plotParamsPhoton.push_back({"Photon", tag+"Match", "Mass",   makePDCPhotonMatch_single(tag, "M","single"),   "single", nBins, minMassPhoton, maxMassPhoton, false, false, label_PhotonMass,   label_map[tag+"Match_single"], true});
-      plotParamsPhoton.push_back({"Photon", tag+"Match", "Eta",    makePDCPhotonMatch_single(tag, "eta","single"), "single", nBins, minEta, maxEta,               false, false, label_PhotonEta,    label_map[tag+"Match_single"], true});
-      plotParamsPhoton.push_back({"Photon", tag+"Match", "Phi",    makePDCPhotonMatch_single(tag, "phi","single"), "single", nBins, minPhi, maxPhi,               false, false, label_PhotonPhi,    label_map[tag+"Match_single"], true});
-      plotParamsPhoton.push_back({"Photon", tag+"Match", "Pt",     makePDCPhotonMatch_ratio(tag, "pt","ratio"),    "ratio",  nBins, minPt, maxPt,                 false, false, label_PhotonPt,     label_map[tag+"Match_ratio"], true});
-      plotParamsPhoton.push_back({"Photon", tag+"Match", "Energy", makePDCPhotonMatch_ratio(tag, "E","ratio"),     "ratio",  nBins, minEnergy, maxEnergy,         false, false, label_PhotonEnergy, label_map[tag+"Match_ratio"], true});
-      plotParamsPhoton.push_back({"Photon", tag+"Match", "Mass",   makePDCPhotonMatch_ratio(tag, "M","ratio"),     "ratio",  nBins, minMassPhoton, maxMassPhoton, false, false, label_PhotonMass,   label_map[tag+"Match_ratio"], true});
-      plotParamsPhoton.push_back({"Photon", tag+"Match", "Eta",    makePDCPhotonMatch_ratio(tag, "eta","ratio"),   "ratio",  nBins, minEta, maxEta,               false, false, label_PhotonEta,    label_map[tag+"Match_ratio"], true});
-      plotParamsPhoton.push_back({"Photon", tag+"Match", "Phi",    makePDCPhotonMatch_ratio(tag, "phi","ratio"),   "ratio",  nBins, minPhi, maxPhi,               false, false, label_PhotonPhi,    label_map[tag+"Match_ratio"], true});
       // Iso
       // only iso for reco
       if (tag.compare("Reco") == 0)
@@ -676,6 +677,17 @@ int main(int argc, char* argv[])
         plotParamsPhoton.push_back({"Photon", tag+"Iso", "Eta",    makePDCPhotonIso_ratio(tag, "eta","ratio"),   "ratio",  nBins, minEta, maxEta,                   false, false, label_PhotonEta,    label_map[tag+"Iso_ratio"], true});
         plotParamsPhoton.push_back({"Photon", tag+"Iso", "Phi",    makePDCPhotonIso_ratio(tag, "phi","ratio"),   "ratio",  nBins, minPhi, maxPhi,                   false, false, label_PhotonPhi,    label_map[tag+"Iso_ratio"], true});
       }
+      // Match
+      plotParamsPhoton.push_back({"Photon", tag+"Match", "Pt",     makePDCPhotonMatch_single(tag, "pt","single"),  "single", nBins, minPt, maxPt,                 true, false,  label_PhotonPt,     label_map[tag+"Match_single"], true});
+      plotParamsPhoton.push_back({"Photon", tag+"Match", "Energy", makePDCPhotonMatch_single(tag, "E","single"),   "single", nBins, minEnergy, maxEnergy,         true, false,  label_PhotonEnergy, label_map[tag+"Match_single"], true});
+      plotParamsPhoton.push_back({"Photon", tag+"Match", "Mass",   makePDCPhotonMatch_single(tag, "M","single"),   "single", nBins, minMassPhoton, maxMassPhoton, false, false, label_PhotonMass,   label_map[tag+"Match_single"], true});
+      plotParamsPhoton.push_back({"Photon", tag+"Match", "Eta",    makePDCPhotonMatch_single(tag, "eta","single"), "single", nBins, minEta, maxEta,               false, false, label_PhotonEta,    label_map[tag+"Match_single"], true});
+      plotParamsPhoton.push_back({"Photon", tag+"Match", "Phi",    makePDCPhotonMatch_single(tag, "phi","single"), "single", nBins, minPhi, maxPhi,               false, false, label_PhotonPhi,    label_map[tag+"Match_single"], true});
+      plotParamsPhoton.push_back({"Photon", tag+"Match", "Pt",     makePDCPhotonMatch_ratio(tag, "pt","ratio"),    "ratio",  nBins, minPt, maxPt,                 false, false, label_PhotonPt,     label_map[tag+"Match_ratio"], true});
+      plotParamsPhoton.push_back({"Photon", tag+"Match", "Energy", makePDCPhotonMatch_ratio(tag, "E","ratio"),     "ratio",  nBins, minEnergy, maxEnergy,         false, false, label_PhotonEnergy, label_map[tag+"Match_ratio"], true});
+      plotParamsPhoton.push_back({"Photon", tag+"Match", "Mass",   makePDCPhotonMatch_ratio(tag, "M","ratio"),     "ratio",  nBins, minMassPhoton, maxMassPhoton, false, false, label_PhotonMass,   label_map[tag+"Match_ratio"], true});
+      plotParamsPhoton.push_back({"Photon", tag+"Match", "Eta",    makePDCPhotonMatch_ratio(tag, "eta","ratio"),   "ratio",  nBins, minEta, maxEta,               false, false, label_PhotonEta,    label_map[tag+"Match_ratio"], true});
+      plotParamsPhoton.push_back({"Photon", tag+"Match", "Phi",    makePDCPhotonMatch_ratio(tag, "phi","ratio"),   "ratio",  nBins, minPhi, maxPhi,               false, false, label_PhotonPhi,    label_map[tag+"Match_ratio"], true});
     }
     
     if (doLeptons)

--- a/Tools/MakePlots.C
+++ b/Tools/MakePlots.C
@@ -360,8 +360,8 @@ int main(int argc, char* argv[])
     auto makePDCMuIso_ratio    = [&](const std::string& var, const std::string& style) {return Plotter::DataCollection(style, {{"genMatchIsoMuInAcc("+var+")",   makePDSMu("#mu iso over reco")}, {"genMatchMuInAcc("+var+")",   makePDSMu("#mu iso over reco")}}); };
     // photons
     // only passing pt cut: ratio = gammaLVecGenPtCut / gammaLVecGen
-    auto makePDCPhotonPtCut_single  = [&](const std::string& var, const std::string& style) {return Plotter::DataCollection(style, {{"gammaLVecGenPtCut("+var+")", makePDSPhoton("acc")},           {"gammaLVecGen("+var+")", makePDSPhoton("gen")}}); };
-    auto makePDCPhotonPtCut_ratio   = [&](const std::string& var, const std::string& style) {return Plotter::DataCollection(style, {{"gammaLVecGenPtCut("+var+")", makePDSPhoton("acc over gen")},  {"gammaLVecGen("+var+")", makePDSPhoton("acc over gen")}}); };
+    auto makePDCPhotonPtCut_single  = [&](const std::string& var, const std::string& style) {return Plotter::DataCollection(style, {{"gammaLVecGenAcc("+var+")", makePDSPhoton("acc")},                {"gammaLVecGenPtCut("+var+")", makePDSPhoton("genPtCut")}}); };
+    auto makePDCPhotonPtCut_ratio   = [&](const std::string& var, const std::string& style) {return Plotter::DataCollection(style, {{"gammaLVecGenAcc("+var+")", makePDSPhoton("acc over genPtCut")},  {"gammaLVecGenPtCut("+var+")", makePDSPhoton("acc over genPtCut")}}); };
     // acceptance = gammaLVecGenAcc / gammaLVecGen (acc / gen)
     auto makePDCPhotonAcc_single  = [&](const std::string& var, const std::string& style) {return Plotter::DataCollection(style, {{"gammaLVecGenAcc("+var+")", makePDSPhoton("acc")},           {"gammaLVecGen("+var+")", makePDSPhoton("gen")}}); };
     auto makePDCPhotonAcc_ratio   = [&](const std::string& var, const std::string& style) {return Plotter::DataCollection(style, {{"gammaLVecGenAcc("+var+")", makePDSPhoton("acc over gen")},  {"gammaLVecGen("+var+")", makePDSPhoton("acc over gen")}}); };

--- a/Tools/MakePlots.C
+++ b/Tools/MakePlots.C
@@ -365,18 +365,18 @@ int main(int argc, char* argv[])
     // acceptance = gammaLVecGenAcc / gammaLVecGen (acc / gen)
     auto makePDCPhotonAcc_single  = [&](const std::string& var, const std::string& style) {return Plotter::DataCollection(style, {{"gammaLVecGenAcc("+var+")", makePDSPhoton("acc")},           {"gammaLVecGen("+var+")", makePDSPhoton("gen")}}); };
     auto makePDCPhotonAcc_ratio   = [&](const std::string& var, const std::string& style) {return Plotter::DataCollection(style, {{"gammaLVecGenAcc("+var+")", makePDSPhoton("acc over gen")},  {"gammaLVecGen("+var+")", makePDSPhoton("acc over gen")}}); };
-    // reco efficiency = gammaLVecRecoAcc / gammaLVecGenAcc (reco / acc)
-    auto makePDCPhotonReco_single = [&](const std::string& var, const std::string& style) {return Plotter::DataCollection(style, {{"gammaLVecRecoAcc("+var+")", makePDSPhoton("reco")},             {"gammaLVecGenAcc("+var+")", makePDSPhoton("acc")}}); };
-    auto makePDCPhotonReco_ratio  = [&](const std::string& var, const std::string& style) {return Plotter::DataCollection(style, {{"gammaLVecRecoAcc("+var+")", makePDSPhoton("reco over acc")},    {"gammaLVecGenAcc("+var+")", makePDSPhoton("reco over acc")}}); };
-    // iso efficiency = gammaLVecIsoAcc / gammaLVecRecoAcc (iso / reco)
-    auto makePDCPhotonIso_single  = [&](const std::string& var, const std::string& style) {return Plotter::DataCollection(style, {{"gammaLVecIsoAcc("+var+")", makePDSPhoton("iso")},           {"gammaLVecRecoAcc("+var+")", makePDSPhoton("reco")}}); };
-    auto makePDCPhotonIso_ratio   = [&](const std::string& var, const std::string& style) {return Plotter::DataCollection(style, {{"gammaLVecIsoAcc("+var+")", makePDSPhoton("iso over reco")}, {"gammaLVecRecoAcc("+var+")", makePDSPhoton("iso over reco")}}); };
+    // reco efficiency = gammaLVecGenRecoMatched / gammaLVecGenAcc (reco / acc)
+    auto makePDCPhotonReco_single = [&](const std::string& var, const std::string& style) {return Plotter::DataCollection(style, {{"gammaLVecGenRecoMatched("+var+")", makePDSPhoton("reco")},             {"gammaLVecGenAcc("+var+")", makePDSPhoton("acc")}}); };
+    auto makePDCPhotonReco_ratio  = [&](const std::string& var, const std::string& style) {return Plotter::DataCollection(style, {{"gammaLVecGenRecoMatched("+var+")", makePDSPhoton("reco over acc")},    {"gammaLVecGenAcc("+var+")", makePDSPhoton("reco over acc")}}); };
+    // iso efficiency = gammaLVecGenIso / gammaLVecGenRecoMatched (iso / reco)
+    auto makePDCPhotonIso_single  = [&](const std::string& var, const std::string& style) {return Plotter::DataCollection(style, {{"gammaLVecGenIso("+var+")", makePDSPhoton("iso")},           {"gammaLVecGenRecoMatched("+var+")", makePDSPhoton("reco")}}); };
+    auto makePDCPhotonIso_ratio   = [&](const std::string& var, const std::string& style) {return Plotter::DataCollection(style, {{"gammaLVecGenIso("+var+")", makePDSPhoton("iso over reco")}, {"gammaLVecGenRecoMatched("+var+")", makePDSPhoton("iso over reco")}}); };
     
 
     // photons gen: gammaLVecGen
     // photons acc: gammaLVecGenAcc
-    // photons reco: gammaLVecRecoAcc
-    // photons iso: gammaLVecIsoAcc
+    // photons reco: gammaLVecGenRecoMatched
+    // photons iso: gammaLVecGenIso
     Plotter::DataCollection dcMC_genPhotonPt(     "single", "gammaLVecGenAcc(pt)",      {dsPhoton});
     Plotter::DataCollection dcMC_genPhotonEta(    "single", "gammaLVecGenAcc(eta)",     {dsPhoton});
     Plotter::DataCollection dcMC_matchedPhotonPt( "single", "promptPhotons(pt)",        {dsPhoton});

--- a/Tools/MakePlots.C
+++ b/Tools/MakePlots.C
@@ -268,14 +268,14 @@ int main(int argc, char* argv[])
     std::string label_genTopPt = "gen top p_{T} [GeV]";
     std::string label_phopt = "p_{T}^{#gamma} [GeV]";
     std::string label_metg = "p_{T}^{#gamma (miss)} [GeV]";
-    std::string label_ptcut_single = "ptcut & gen";
-    std::string label_acc_single = "acc & all";
-    std::string label_matched_single = "matched & acc";
-    std::string label_iso_single = "iso & matched";
-    std::string label_ptcut_ratio = "ptcut/gen";
-    std::string label_acc_ratio = "acc/all";
-    std::string label_matched_ratio = "matched/acc";
-    std::string label_iso_ratio = "iso/matched";
+    std::string label_ptcut_single = "genEtaPt & genPt";
+    std::string label_acc_single = "recoEta & reco";
+    std::string label_matched_single = "recoEtaPtMatched & recoEtaPt";
+    std::string label_iso_single = "recoIso & recoEtaPtMatched";
+    std::string label_ptcut_ratio = "genEtaPt/genPt";
+    std::string label_acc_ratio = "recoEta/reco";
+    std::string label_matched_ratio = "recoEtaPtMatched/recoEtaPt";
+    std::string label_iso_ratio = "recoIso/recoEtaPtMatched";
 
     vector<Plotter::HistSummary> vh;
 
@@ -359,26 +359,26 @@ int main(int argc, char* argv[])
     auto makePDCElecIso_ratio  = [&](const std::string& var, const std::string& style) {return Plotter::DataCollection(style, {{"genMatchIsoElecInAcc("+var+")", makePDSElec("e iso over reco")}, {"genMatchElecInAcc("+var+")", makePDSElec("e iso over reco")}}); };
     auto makePDCMuIso_ratio    = [&](const std::string& var, const std::string& style) {return Plotter::DataCollection(style, {{"genMatchIsoMuInAcc("+var+")",   makePDSMu("#mu iso over reco")}, {"genMatchMuInAcc("+var+")",   makePDSMu("#mu iso over reco")}}); };
     // photons
-    // only passing pt cut: ratio = gammaLVecGenPtCut / gammaLVecGen
-    auto makePDCPhotonPtCut_single  = [&](const std::string& var, const std::string& style) {return Plotter::DataCollection(style, {{"gammaLVecGenAcc("+var+")", makePDSPhoton("genAcc")},                {"gammaLVecGenPtCut("+var+")", makePDSPhoton("genPtCut")}}); };
-    auto makePDCPhotonPtCut_ratio   = [&](const std::string& var, const std::string& style) {return Plotter::DataCollection(style, {{"gammaLVecGenAcc("+var+")", makePDSPhoton("genAcc over genPtCut")},  {"gammaLVecGenPtCut("+var+")", makePDSPhoton("genAcc over genPtCut")}}); };
-    // acceptance = gammaLVecGenAcc / gammaLVecGen (acc / gen)
+    // only passing pt cut: ratio = gammaLVecGenPt / gammaLVecGen
+    auto makePDCPhotonPtCut_single  = [&](const std::string& var, const std::string& style) {return Plotter::DataCollection(style, {{"gammaLVecGenEtaPt("+var+")", makePDSPhoton("genEtaPt")},                {"gammaLVecGenPt("+var+")", makePDSPhoton("genPt")}}); };
+    auto makePDCPhotonPtCut_ratio   = [&](const std::string& var, const std::string& style) {return Plotter::DataCollection(style, {{"gammaLVecGenEtaPt("+var+")", makePDSPhoton("genEtaPt over genPt")},  {"gammaLVecGenPt("+var+")", makePDSPhoton("genEtaPt over genPt")}}); };
+    // acceptance = gammaLVecGenEtaPt / gammaLVecGen (acc / gen)
     auto makePDCPhotonAcc_single  = [&](const std::string& var, const std::string& style) {return Plotter::DataCollection(style, {{"gammaLVecRecoEta("+var+")", makePDSPhoton("recoEta")},           {"gammaLVec("+var+")", makePDSPhoton("reco")}}); };
     auto makePDCPhotonAcc_ratio   = [&](const std::string& var, const std::string& style) {return Plotter::DataCollection(style, {{"gammaLVecRecoEta("+var+")", makePDSPhoton("recoEta over reco")}, {"gammaLVec("+var+")", makePDSPhoton("recoEta over reco")}}); };
-    // reco efficiency = gammaLVecGenRecoMatched / gammaLVecGenAcc (reco / acc)
-    auto makePDCPhotonReco_single = [&](const std::string& var, const std::string& style) {return Plotter::DataCollection(style, {{"gammaLVecRecoEtaPtMatched("+var+")", makePDSPhoton("reco")},             {"gammaLVecRecoEtaPt("+var+")", makePDSPhoton("acc")}}); };
-    auto makePDCPhotonReco_ratio  = [&](const std::string& var, const std::string& style) {return Plotter::DataCollection(style, {{"gammaLVecRecoEtaPtMatched("+var+")", makePDSPhoton("reco over acc")},    {"gammaLVecRecoEtaPt("+var+")", makePDSPhoton("reco over acc")}}); };
+    // reco efficiency = gammaLVecGenRecoMatched / gammaLVecGenEtaPt (reco / acc)
+    auto makePDCPhotonReco_single = [&](const std::string& var, const std::string& style) {return Plotter::DataCollection(style, {{"gammaLVecRecoEtaPtMatched("+var+")", makePDSPhoton("recoEtaPtMatched")},                {"gammaLVecRecoEtaPt("+var+")", makePDSPhoton("recoEtaPt")}}); };
+    auto makePDCPhotonReco_ratio  = [&](const std::string& var, const std::string& style) {return Plotter::DataCollection(style, {{"gammaLVecRecoEtaPtMatched("+var+")", makePDSPhoton("recoEtaPtMatched over recoEtaPt")}, {"gammaLVecRecoEtaPt("+var+")", makePDSPhoton("recoEtaPtMatched over recoEtaPt")}}); };
     // iso efficiency = gammaLVecGenIso / gammaLVecGenRecoMatched (iso / reco)
-    auto makePDCPhotonIso_single  = [&](const std::string& var, const std::string& style) {return Plotter::DataCollection(style, {{"gammaLVecRecoIso("+var+")", makePDSPhoton("iso")},           {"gammaLVecRecoEtaPtMatched("+var+")", makePDSPhoton("reco")}}); };
-    auto makePDCPhotonIso_ratio   = [&](const std::string& var, const std::string& style) {return Plotter::DataCollection(style, {{"gammaLVecRecoIso("+var+")", makePDSPhoton("iso over reco")}, {"gammaLVecRecoEtaPtMatched("+var+")", makePDSPhoton("iso over reco")}}); };
+    auto makePDCPhotonIso_single  = [&](const std::string& var, const std::string& style) {return Plotter::DataCollection(style, {{"gammaLVecRecoIso("+var+")", makePDSPhoton("recoIso")},                       {"gammaLVecRecoEtaPtMatched("+var+")", makePDSPhoton("recoEtaPtMatched")}}); };
+    auto makePDCPhotonIso_ratio   = [&](const std::string& var, const std::string& style) {return Plotter::DataCollection(style, {{"gammaLVecRecoIso("+var+")", makePDSPhoton("recoIso over recoEtaPtMatched")}, {"gammaLVecRecoEtaPtMatched("+var+")", makePDSPhoton("recoIso over recoEtaPtMatched")}}); };
     
 
     // photons gen: gammaLVecGen
-    // photons acc: gammaLVecGenAcc
+    // photons acc: gammaLVecGenEtaPt
     // photons reco: gammaLVecGenRecoMatched
     // photons iso: gammaLVecGenIso
-    Plotter::DataCollection dcMC_genPhotonPt(     "single", "gammaLVecGenAcc(pt)",      {dsPhoton});
-    Plotter::DataCollection dcMC_genPhotonEta(    "single", "gammaLVecGenAcc(eta)",     {dsPhoton});
+    Plotter::DataCollection dcMC_genPhotonPt(     "single", "gammaLVecGenEtaPt(pt)",      {dsPhoton});
+    Plotter::DataCollection dcMC_genPhotonEta(    "single", "gammaLVecGenEtaPt(eta)",     {dsPhoton});
     Plotter::DataCollection dcMC_matchedPhotonPt( "single", "promptPhotons(pt)",        {dsPhoton});
     Plotter::DataCollection dcMC_matchedPhotonEta("single", "promptPhotons(eta)",       {dsPhoton});
 

--- a/Tools/MakePlots.C
+++ b/Tools/MakePlots.C
@@ -135,7 +135,7 @@ int main(int argc, char* argv[])
         //doPlots = false;
         fromTuple = true;
         doPhotons = true;
-        doLeptons = true;
+        doLeptons = false;
         sampleloc = "condor";
     }
 
@@ -268,14 +268,30 @@ int main(int argc, char* argv[])
     std::string label_genTopPt = "gen top p_{T} [GeV]";
     std::string label_phopt = "p_{T}^{#gamma} [GeV]";
     std::string label_metg = "p_{T}^{#gamma (miss)} [GeV]";
-    std::string label_ptcut_single = "genEtaPt & genPt";
-    std::string label_acc_single = "recoEta & reco";
-    std::string label_matched_single = "recoEtaPtMatched & recoEtaPt";
-    std::string label_iso_single = "recoIso & recoEtaPtMatched";
-    std::string label_ptcut_ratio = "genEtaPt/genPt";
-    std::string label_acc_ratio = "recoEta/reco";
-    std::string label_matched_ratio = "recoEtaPtMatched/recoEtaPt";
-    std::string label_iso_ratio = "recoIso/recoEtaPtMatched";
+    std::string label_ptcut_single = "GenEtaPt & GenPt";
+    std::string label_ptcut_ratio  = "GenEtaPt / GenPt";
+    std::string label_acc_single = "RecoEta & Reco";
+    std::string label_acc_ratio  = "RecoEta / Reco";
+    std::string label_matched_single = "RecoEtaPtMatched & RecoEtaPt";
+    std::string label_matched_ratio  = "RecoEtaPtMatched / RecoEtaPt";
+    std::string label_iso_single = "RecoIso & RecoEtaPtMatched";
+    std::string label_iso_ratio  = "RecoIso / RecoEtaPtMatched";
+    // make a map of labels
+    //std::vector<std::pair<std::string,std::string>> cutlevels_electrons
+    std::map<std::string, std::string> label_map = {
+        {"GenAcc_single",     "GenEta & Gen"},
+        {"GenAcc_ratio",      "GenEta / Gen"},
+        {"GenMatch_single",   "GenEtaPtMatched & GenEtaPt"},
+        {"GenMatch_ratio",    "GenEtaPtMatched / GenEtaPt"},
+        {"GenIso_single",     "GenIso & GenEtaPtMatched"},
+        {"GenIso_ratio",      "GenIso / GenEtaPtMatched"},
+        {"RecoAcc_single",    "RecoEta & Reco"},
+        {"RecoAcc_ratio",     "RecoEta / Reco"},
+        {"RecoMatch_single",  "RecoEtaPtMatched & RecoEtaPt"},
+        {"RecoMatch_ratio",   "RecoEtaPtMatched / RecoEtaPt"},
+        {"RecoIso_single",    "RecoIso & RecoEtaPtMatched"},
+        {"RecoIso_ratio",     "RecoIso / RecoEtaPtMatched"},
+    };
 
     vector<Plotter::HistSummary> vh;
 
@@ -360,17 +376,18 @@ int main(int argc, char* argv[])
     auto makePDCMuIso_ratio    = [&](const std::string& var, const std::string& style) {return Plotter::DataCollection(style, {{"genMatchIsoMuInAcc("+var+")",   makePDSMu("#mu iso over reco")}, {"genMatchMuInAcc("+var+")",   makePDSMu("#mu iso over reco")}}); };
     // photons
     // only passing pt cut: ratio = gammaLVecGenPt / gammaLVecGen
-    auto makePDCPhotonPtCut_single  = [&](const std::string& var, const std::string& style) {return Plotter::DataCollection(style, {{"gammaLVecGenEtaPt("+var+")", makePDSPhoton("genEtaPt")},                {"gammaLVecGenPt("+var+")", makePDSPhoton("genPt")}}); };
-    auto makePDCPhotonPtCut_ratio   = [&](const std::string& var, const std::string& style) {return Plotter::DataCollection(style, {{"gammaLVecGenEtaPt("+var+")", makePDSPhoton("genEtaPt over genPt")},  {"gammaLVecGenPt("+var+")", makePDSPhoton("genEtaPt over genPt")}}); };
-    // acceptance = gammaLVecGenEtaPt / gammaLVecGen (acc / gen)
-    auto makePDCPhotonAcc_single  = [&](const std::string& var, const std::string& style) {return Plotter::DataCollection(style, {{"gammaLVecRecoEta("+var+")", makePDSPhoton("recoEta")},           {"gammaLVec("+var+")", makePDSPhoton("reco")}}); };
-    auto makePDCPhotonAcc_ratio   = [&](const std::string& var, const std::string& style) {return Plotter::DataCollection(style, {{"gammaLVecRecoEta("+var+")", makePDSPhoton("recoEta over reco")}, {"gammaLVec("+var+")", makePDSPhoton("recoEta over reco")}}); };
-    // reco efficiency = gammaLVecGenRecoMatched / gammaLVecGenEtaPt (reco / acc)
-    auto makePDCPhotonReco_single = [&](const std::string& var, const std::string& style) {return Plotter::DataCollection(style, {{"gammaLVecRecoEtaPtMatched("+var+")", makePDSPhoton("recoEtaPtMatched")},                {"gammaLVecRecoEtaPt("+var+")", makePDSPhoton("recoEtaPt")}}); };
-    auto makePDCPhotonReco_ratio  = [&](const std::string& var, const std::string& style) {return Plotter::DataCollection(style, {{"gammaLVecRecoEtaPtMatched("+var+")", makePDSPhoton("recoEtaPtMatched over recoEtaPt")}, {"gammaLVecRecoEtaPt("+var+")", makePDSPhoton("recoEtaPtMatched over recoEtaPt")}}); };
-    // iso efficiency = gammaLVecGenIso / gammaLVecGenRecoMatched (iso / reco)
-    auto makePDCPhotonIso_single  = [&](const std::string& var, const std::string& style) {return Plotter::DataCollection(style, {{"gammaLVecRecoIso("+var+")", makePDSPhoton("recoIso")},                       {"gammaLVecRecoEtaPtMatched("+var+")", makePDSPhoton("recoEtaPtMatched")}}); };
-    auto makePDCPhotonIso_ratio   = [&](const std::string& var, const std::string& style) {return Plotter::DataCollection(style, {{"gammaLVecRecoIso("+var+")", makePDSPhoton("recoIso over recoEtaPtMatched")}, {"gammaLVecRecoEtaPtMatched("+var+")", makePDSPhoton("recoIso over recoEtaPtMatched")}}); };
+    //auto makePDCPhotonPtCut_single  = [&](const std::string& var, const std::string& style) {return Plotter::DataCollection(style, {{"gammaLVecGenEtaPt("+var+")", makePDSPhoton("genEtaPt")},                {"gammaLVecGenPt("+var+")", makePDSPhoton("genPt")}}); };
+    //auto makePDCPhotonPtCut_ratio   = [&](const std::string& var, const std::string& style) {return Plotter::DataCollection(style, {{"gammaLVecGenEtaPt("+var+")", makePDSPhoton("genEtaPt over genPt")},  {"gammaLVecGenPt("+var+")", makePDSPhoton("genEtaPt over genPt")}}); };
+    // Tag must be Gen or Reco
+    // acceptance = gammaLVecTagEtaPt / gammaLVecTag (acc / gen)
+    auto makePDCPhotonAcc_single   = [&](const std::string& tag, const std::string& var, const std::string& style) {return Plotter::DataCollection(style, {{"gammaLVec"+tag+"Eta("+var+")", makePDSPhoton(tag+"Eta")},           {"gammaLVec"+tag+"("+var+")", makePDSPhoton(tag)}}); };
+    auto makePDCPhotonAcc_ratio    = [&](const std::string& tag, const std::string& var, const std::string& style) {return Plotter::DataCollection(style, {{"gammaLVec"+tag+"Eta("+var+")", makePDSPhoton(tag+"Eta over "+tag)}, {"gammaLVec"+tag+"("+var+")", makePDSPhoton(tag+"Eta over "+tag)}}); };
+    // match efficiency = gammaLVecTagMatched / gammaLVecTagEtaPt (match / acc)
+    auto makePDCPhotonMatch_single = [&](const std::string& tag, const std::string& var, const std::string& style) {return Plotter::DataCollection(style, {{"gammaLVec"+tag+"EtaPtMatched("+var+")", makePDSPhoton(tag+"EtaPtMatched")},                   {"gammaLVec"+tag+"EtaPt("+var+")", makePDSPhoton(tag+"EtaPt")}}); };
+    auto makePDCPhotonMatch_ratio  = [&](const std::string& tag, const std::string& var, const std::string& style) {return Plotter::DataCollection(style, {{"gammaLVec"+tag+"EtaPtMatched("+var+")", makePDSPhoton(tag+"EtaPtMatched over "+tag+"EtaPt")}, {"gammaLVec"+tag+"EtaPt("+var+")", makePDSPhoton(tag+"EtaPtMatched over "+tag+"EtaPt")}}); };
+    // iso efficiency = gammaLVecTagIso / gammaLVecTagMatched (iso / match)
+    auto makePDCPhotonIso_single   = [&](const std::string& tag, const std::string& var, const std::string& style) {return Plotter::DataCollection(style, {{"gammaLVec"+tag+"Iso("+var+")", makePDSPhoton(tag+"Iso")},                          {"gammaLVec"+tag+"EtaPtMatched("+var+")", makePDSPhoton(tag+"EtaPtMatched")}}); };
+    auto makePDCPhotonIso_ratio    = [&](const std::string& tag, const std::string& var, const std::string& style) {return Plotter::DataCollection(style, {{"gammaLVec"+tag+"Iso("+var+")", makePDSPhoton(tag+"Iso over "+tag+"EtaPtMatched")}, {"gammaLVec"+tag+"EtaPtMatched("+var+")", makePDSPhoton(tag+"Iso over "+tag+"EtaPtMatched")}}); };
     
 
     // photons gen: gammaLVecGen
@@ -607,49 +624,55 @@ int main(int argc, char* argv[])
     std::vector<plotStruct> plotParamsPhoton;
     
     // pt cut
-    plotParamsPhoton.push_back({"Photon", "PtCut", "Pt",     makePDCPhotonPtCut_single("pt","single"),  "single", nBins, minPt, maxPt, true, false, label_PhotonPt, label_ptcut_single, true});
-    plotParamsPhoton.push_back({"Photon", "PtCut", "Energy", makePDCPhotonPtCut_single("E","single"),   "single", nBins, minEnergy, maxEnergy, true, false, label_PhotonEnergy, label_ptcut_single, true});
-    plotParamsPhoton.push_back({"Photon", "PtCut", "Mass",   makePDCPhotonPtCut_single("M","single"),   "single", nBins, minMassPhoton, maxMassPhoton, false, false, label_PhotonMass, label_ptcut_single, true});
-    plotParamsPhoton.push_back({"Photon", "PtCut", "Eta",    makePDCPhotonPtCut_single("eta","single"), "single", nBins, minEta, maxEta, false, false, label_PhotonEta, label_ptcut_single, true});
-    plotParamsPhoton.push_back({"Photon", "PtCut", "Phi",    makePDCPhotonPtCut_single("phi","single"), "single", nBins, minPhi, maxPhi, false, false, label_PhotonPhi, label_ptcut_single, true});
-    plotParamsPhoton.push_back({"Photon", "PtCut", "Pt",     makePDCPhotonPtCut_ratio("pt","ratio"),    "ratio",  nBins, minPt, maxPt, false, false, label_PhotonPt, label_ptcut_ratio, true});
-    plotParamsPhoton.push_back({"Photon", "PtCut", "Energy", makePDCPhotonPtCut_ratio("E","ratio"),     "ratio",  nBins, minEnergy, maxEnergy, false, false, label_PhotonEnergy, label_ptcut_ratio, true});
-    plotParamsPhoton.push_back({"Photon", "PtCut", "Mass",   makePDCPhotonPtCut_ratio("M","ratio"),     "ratio",  nBins, minMassPhoton, maxMassPhoton, false, false, label_PhotonMass, label_ptcut_ratio, true});
-    plotParamsPhoton.push_back({"Photon", "PtCut", "Eta",    makePDCPhotonPtCut_ratio("eta","ratio"),   "ratio",  nBins, minEta, maxEta, false, false, label_PhotonEta, label_ptcut_ratio, true});
-    plotParamsPhoton.push_back({"Photon", "PtCut", "Phi",    makePDCPhotonPtCut_ratio("phi","ratio"),   "ratio",  nBins, minPhi, maxPhi, false, false, label_PhotonPhi, label_ptcut_ratio, true});
-    // Acc
-    plotParamsPhoton.push_back({"Photon", "Acc", "Pt",     makePDCPhotonAcc_single("pt","single"),  "single", nBins, minPt, maxPt, true, false, label_PhotonPt, label_acc_single, true});
-    plotParamsPhoton.push_back({"Photon", "Acc", "Energy", makePDCPhotonAcc_single("E","single"),   "single", nBins, minEnergy, maxEnergy, true, false, label_PhotonEnergy, label_acc_single, true});
-    plotParamsPhoton.push_back({"Photon", "Acc", "Mass",   makePDCPhotonAcc_single("M","single"),   "single", nBins, minMassPhoton, maxMassPhoton, false, false, label_PhotonMass, label_acc_single, true});
-    plotParamsPhoton.push_back({"Photon", "Acc", "Eta",    makePDCPhotonAcc_single("eta","single"), "single", nBins, minEta, maxEta, false, false, label_PhotonEta, label_acc_single, true});
-    plotParamsPhoton.push_back({"Photon", "Acc", "Phi",    makePDCPhotonAcc_single("phi","single"), "single", nBins, minPhi, maxPhi, false, false, label_PhotonPhi, label_acc_single, true});
-    plotParamsPhoton.push_back({"Photon", "Acc", "Pt",     makePDCPhotonAcc_ratio("pt","ratio"),    "ratio",  nBins, minPt, maxPt, false, false, label_PhotonPt, label_acc_ratio, true});
-    plotParamsPhoton.push_back({"Photon", "Acc", "Energy", makePDCPhotonAcc_ratio("E","ratio"),     "ratio",  nBins, minEnergy, maxEnergy, false, false, label_PhotonEnergy, label_acc_ratio, true});
-    plotParamsPhoton.push_back({"Photon", "Acc", "Mass",   makePDCPhotonAcc_ratio("M","ratio"),     "ratio",  nBins, minMassPhoton, maxMassPhoton, false, false, label_PhotonMass, label_acc_ratio, true});
-    plotParamsPhoton.push_back({"Photon", "Acc", "Eta",    makePDCPhotonAcc_ratio("eta","ratio"),   "ratio",  nBins, minEta, maxEta, false, false, label_PhotonEta, label_acc_ratio, true});
-    plotParamsPhoton.push_back({"Photon", "Acc", "Phi",    makePDCPhotonAcc_ratio("phi","ratio"),   "ratio",  nBins, minPhi, maxPhi, false, false, label_PhotonPhi, label_acc_ratio, true});
-    // Reco
-    plotParamsPhoton.push_back({"Photon", "Reco", "Pt",     makePDCPhotonReco_single("pt","single"),  "single", nBins, minPt, maxPt, true, false, label_PhotonPt, label_matched_single, true});
-    plotParamsPhoton.push_back({"Photon", "Reco", "Energy", makePDCPhotonReco_single("E","single"),   "single", nBins, minEnergy, maxEnergy, true, false, label_PhotonEnergy, label_matched_single, true});
-    plotParamsPhoton.push_back({"Photon", "Reco", "Mass",   makePDCPhotonReco_single("M","single"),   "single", nBins, minMassPhoton, maxMassPhoton, false, false, label_PhotonMass, label_matched_single, true});
-    plotParamsPhoton.push_back({"Photon", "Reco", "Eta",    makePDCPhotonReco_single("eta","single"), "single", nBins, minEta, maxEta, false, false, label_PhotonEta, label_matched_single, true});
-    plotParamsPhoton.push_back({"Photon", "Reco", "Phi",    makePDCPhotonReco_single("phi","single"), "single", nBins, minPhi, maxPhi, false, false, label_PhotonPhi, label_matched_single, true});
-    plotParamsPhoton.push_back({"Photon", "Reco", "Pt",     makePDCPhotonReco_ratio("pt","ratio"),    "ratio",  nBins, minPt, maxPt, false, false, label_PhotonPt, label_matched_ratio, true});
-    plotParamsPhoton.push_back({"Photon", "Reco", "Energy", makePDCPhotonReco_ratio("E","ratio"),     "ratio",  nBins, minEnergy, maxEnergy, false, false, label_PhotonEnergy, label_matched_ratio, true});
-    plotParamsPhoton.push_back({"Photon", "Reco", "Mass",   makePDCPhotonReco_ratio("M","ratio"),     "ratio",  nBins, minMassPhoton, maxMassPhoton, false, false, label_PhotonMass, label_matched_ratio, true});
-    plotParamsPhoton.push_back({"Photon", "Reco", "Eta",    makePDCPhotonReco_ratio("eta","ratio"),   "ratio",  nBins, minEta, maxEta, false, false, label_PhotonEta, label_matched_ratio, true});
-    plotParamsPhoton.push_back({"Photon", "Reco", "Phi",    makePDCPhotonReco_ratio("phi","ratio"),   "ratio",  nBins, minPhi, maxPhi, false, false, label_PhotonPhi, label_matched_ratio, true});
-    // Iso
-    plotParamsPhoton.push_back({"Photon", "Iso", "Pt",     makePDCPhotonIso_single("pt","single"),  "single", nBins, minPt, maxPt, true, false, label_PhotonPt, label_iso_single, true});
-    plotParamsPhoton.push_back({"Photon", "Iso", "Energy", makePDCPhotonIso_single("E","single"),   "single", nBins, minEnergy, maxEnergy, true, false, label_PhotonEnergy, label_iso_single, true});
-    plotParamsPhoton.push_back({"Photon", "Iso", "Mass",   makePDCPhotonIso_single("M","single"),   "single", nBins, minMassPhoton, maxMassPhoton, false, false, label_PhotonMass, label_iso_single, true});
-    plotParamsPhoton.push_back({"Photon", "Iso", "Eta",    makePDCPhotonIso_single("eta","single"), "single", nBins, minEta, maxEta, false, false, label_PhotonEta, label_iso_single, true});
-    plotParamsPhoton.push_back({"Photon", "Iso", "Phi",    makePDCPhotonIso_single("phi","single"), "single", nBins, minPhi, maxPhi, false, false, label_PhotonPhi, label_iso_single, true});
-    plotParamsPhoton.push_back({"Photon", "Iso", "Pt",     makePDCPhotonIso_ratio("pt","ratio"),    "ratio",  nBins, minPt, maxPt, false, false, label_PhotonPt, label_iso_ratio, true});
-    plotParamsPhoton.push_back({"Photon", "Iso", "Energy", makePDCPhotonIso_ratio("E","ratio"),     "ratio",  nBins, minEnergy, maxEnergy, false, false, label_PhotonEnergy, label_iso_ratio, true});
-    plotParamsPhoton.push_back({"Photon", "Iso", "Mass",   makePDCPhotonIso_ratio("M","ratio"),     "ratio",  nBins, minMassPhoton, maxMassPhoton, false, false, label_PhotonMass, label_iso_ratio, true});
-    plotParamsPhoton.push_back({"Photon", "Iso", "Eta",    makePDCPhotonIso_ratio("eta","ratio"),   "ratio",  nBins, minEta, maxEta, false, false, label_PhotonEta, label_iso_ratio, true});
-    plotParamsPhoton.push_back({"Photon", "Iso", "Phi",    makePDCPhotonIso_ratio("phi","ratio"),   "ratio",  nBins, minPhi, maxPhi, false, false, label_PhotonPhi, label_iso_ratio, true});
+    //plotParamsPhoton.push_back({"Photon", "PtCut", "Pt",     makePDCPhotonPtCut_single("pt","single"),  "single", nBins, minPt, maxPt, true, false, label_PhotonPt, label_ptcut_single, true});
+    //plotParamsPhoton.push_back({"Photon", "PtCut", "Energy", makePDCPhotonPtCut_single("E","single"),   "single", nBins, minEnergy, maxEnergy, true, false, label_PhotonEnergy, label_ptcut_single, true});
+    //plotParamsPhoton.push_back({"Photon", "PtCut", "Mass",   makePDCPhotonPtCut_single("M","single"),   "single", nBins, minMassPhoton, maxMassPhoton, false, false, label_PhotonMass, label_ptcut_single, true});
+    //plotParamsPhoton.push_back({"Photon", "PtCut", "Eta",    makePDCPhotonPtCut_single("eta","single"), "single", nBins, minEta, maxEta, false, false, label_PhotonEta, label_ptcut_single, true});
+    //plotParamsPhoton.push_back({"Photon", "PtCut", "Phi",    makePDCPhotonPtCut_single("phi","single"), "single", nBins, minPhi, maxPhi, false, false, label_PhotonPhi, label_ptcut_single, true});
+    //plotParamsPhoton.push_back({"Photon", "PtCut", "Pt",     makePDCPhotonPtCut_ratio("pt","ratio"),    "ratio",  nBins, minPt, maxPt, false, false, label_PhotonPt, label_ptcut_ratio, true});
+    //plotParamsPhoton.push_back({"Photon", "PtCut", "Energy", makePDCPhotonPtCut_ratio("E","ratio"),     "ratio",  nBins, minEnergy, maxEnergy, false, false, label_PhotonEnergy, label_ptcut_ratio, true});
+    //plotParamsPhoton.push_back({"Photon", "PtCut", "Mass",   makePDCPhotonPtCut_ratio("M","ratio"),     "ratio",  nBins, minMassPhoton, maxMassPhoton, false, false, label_PhotonMass, label_ptcut_ratio, true});
+    //plotParamsPhoton.push_back({"Photon", "PtCut", "Eta",    makePDCPhotonPtCut_ratio("eta","ratio"),   "ratio",  nBins, minEta, maxEta, false, false, label_PhotonEta, label_ptcut_ratio, true});
+    //plotParamsPhoton.push_back({"Photon", "PtCut", "Phi",    makePDCPhotonPtCut_ratio("phi","ratio"),   "ratio",  nBins, minPhi, maxPhi, false, false, label_PhotonPhi, label_ptcut_ratio, true});
+
+    // Tag must be Gen or Reco
+    std::vector<std::string> tags = {"Gen", "Reco"};
+    for (std::string tag : tags)
+    {
+      // Acc
+      plotParamsPhoton.push_back({"Photon", tag+"Acc", "Pt",     makePDCPhotonAcc_single(tag, "pt","single"),  "single", nBins, minPt, maxPt,                 true,  false, label_PhotonPt,     label_map[tag+"Acc_single"], true});
+      plotParamsPhoton.push_back({"Photon", tag+"Acc", "Energy", makePDCPhotonAcc_single(tag, "E","single"),   "single", nBins, minEnergy, maxEnergy,         true,  false, label_PhotonEnergy, label_map[tag+"Acc_single"], true});
+      plotParamsPhoton.push_back({"Photon", tag+"Acc", "Mass",   makePDCPhotonAcc_single(tag, "M","single"),   "single", nBins, minMassPhoton, maxMassPhoton, false, false, label_PhotonMass,   label_map[tag+"Acc_single"], true});
+      plotParamsPhoton.push_back({"Photon", tag+"Acc", "Eta",    makePDCPhotonAcc_single(tag, "eta","single"), "single", nBins, minEta, maxEta,               false, false, label_PhotonEta,    label_map[tag+"Acc_single"], true});
+      plotParamsPhoton.push_back({"Photon", tag+"Acc", "Phi",    makePDCPhotonAcc_single(tag, "phi","single"), "single", nBins, minPhi, maxPhi,               false, false, label_PhotonPhi,    label_map[tag+"Acc_single"], true});
+      plotParamsPhoton.push_back({"Photon", tag+"Acc", "Pt",     makePDCPhotonAcc_ratio(tag, "pt","ratio"),    "ratio",  nBins, minPt, maxPt,                 false, false, label_PhotonPt,     label_map[tag+"Acc_ratio"], true});
+      plotParamsPhoton.push_back({"Photon", tag+"Acc", "Energy", makePDCPhotonAcc_ratio(tag, "E","ratio"),     "ratio",  nBins, minEnergy, maxEnergy,         false, false, label_PhotonEnergy, label_map[tag+"Acc_ratio"], true});
+      plotParamsPhoton.push_back({"Photon", tag+"Acc", "Mass",   makePDCPhotonAcc_ratio(tag, "M","ratio"),     "ratio",  nBins, minMassPhoton, maxMassPhoton, false, false, label_PhotonMass,   label_map[tag+"Acc_ratio"], true});
+      plotParamsPhoton.push_back({"Photon", tag+"Acc", "Eta",    makePDCPhotonAcc_ratio(tag, "eta","ratio"),   "ratio",  nBins, minEta, maxEta,               false, false, label_PhotonEta,    label_map[tag+"Acc_ratio"], true});
+      plotParamsPhoton.push_back({"Photon", tag+"Acc", "Phi",    makePDCPhotonAcc_ratio(tag, "phi","ratio"),   "ratio",  nBins, minPhi, maxPhi,               false, false, label_PhotonPhi,    label_map[tag+"Acc_ratio"], true});
+      // Match
+      plotParamsPhoton.push_back({"Photon", tag+"Match", "Pt",     makePDCPhotonMatch_single(tag, "pt","single"),  "single", nBins, minPt, maxPt,                 true, false,  label_PhotonPt,     label_map[tag+"Match_single"], true});
+      plotParamsPhoton.push_back({"Photon", tag+"Match", "Energy", makePDCPhotonMatch_single(tag, "E","single"),   "single", nBins, minEnergy, maxEnergy,         true, false,  label_PhotonEnergy, label_map[tag+"Match_single"], true});
+      plotParamsPhoton.push_back({"Photon", tag+"Match", "Mass",   makePDCPhotonMatch_single(tag, "M","single"),   "single", nBins, minMassPhoton, maxMassPhoton, false, false, label_PhotonMass,   label_map[tag+"Match_single"], true});
+      plotParamsPhoton.push_back({"Photon", tag+"Match", "Eta",    makePDCPhotonMatch_single(tag, "eta","single"), "single", nBins, minEta, maxEta,               false, false, label_PhotonEta,    label_map[tag+"Match_single"], true});
+      plotParamsPhoton.push_back({"Photon", tag+"Match", "Phi",    makePDCPhotonMatch_single(tag, "phi","single"), "single", nBins, minPhi, maxPhi,               false, false, label_PhotonPhi,    label_map[tag+"Match_single"], true});
+      plotParamsPhoton.push_back({"Photon", tag+"Match", "Pt",     makePDCPhotonMatch_ratio(tag, "pt","ratio"),    "ratio",  nBins, minPt, maxPt,                 false, false, label_PhotonPt,     label_map[tag+"Match_ratio"], true});
+      plotParamsPhoton.push_back({"Photon", tag+"Match", "Energy", makePDCPhotonMatch_ratio(tag, "E","ratio"),     "ratio",  nBins, minEnergy, maxEnergy,         false, false, label_PhotonEnergy, label_map[tag+"Match_ratio"], true});
+      plotParamsPhoton.push_back({"Photon", tag+"Match", "Mass",   makePDCPhotonMatch_ratio(tag, "M","ratio"),     "ratio",  nBins, minMassPhoton, maxMassPhoton, false, false, label_PhotonMass,   label_map[tag+"Match_ratio"], true});
+      plotParamsPhoton.push_back({"Photon", tag+"Match", "Eta",    makePDCPhotonMatch_ratio(tag, "eta","ratio"),   "ratio",  nBins, minEta, maxEta,               false, false, label_PhotonEta,    label_map[tag+"Match_ratio"], true});
+      plotParamsPhoton.push_back({"Photon", tag+"Match", "Phi",    makePDCPhotonMatch_ratio(tag, "phi","ratio"),   "ratio",  nBins, minPhi, maxPhi,               false, false, label_PhotonPhi,    label_map[tag+"Match_ratio"], true});
+      // Iso
+      plotParamsPhoton.push_back({"Photon", tag+"Iso", "Pt",     makePDCPhotonIso_single(tag, "pt","single"),  "single", nBins, minPt, maxPt,                     true, false,  label_PhotonPt,     label_map[tag+"Iso_single"], true});
+      plotParamsPhoton.push_back({"Photon", tag+"Iso", "Energy", makePDCPhotonIso_single(tag, "E","single"),   "single", nBins, minEnergy, maxEnergy,             true, false,  label_PhotonEnergy, label_map[tag+"Iso_single"], true});
+      plotParamsPhoton.push_back({"Photon", tag+"Iso", "Mass",   makePDCPhotonIso_single(tag, "M","single"),   "single", nBins, minMassPhoton, maxMassPhoton,     false, false, label_PhotonMass,   label_map[tag+"Iso_single"], true});
+      plotParamsPhoton.push_back({"Photon", tag+"Iso", "Eta",    makePDCPhotonIso_single(tag, "eta","single"), "single", nBins, minEta, maxEta,                   false, false, label_PhotonEta,    label_map[tag+"Iso_single"], true});
+      plotParamsPhoton.push_back({"Photon", tag+"Iso", "Phi",    makePDCPhotonIso_single(tag, "phi","single"), "single", nBins, minPhi, maxPhi,                   false, false, label_PhotonPhi,    label_map[tag+"Iso_single"], true});
+      plotParamsPhoton.push_back({"Photon", tag+"Iso", "Pt",     makePDCPhotonIso_ratio(tag, "pt","ratio"),    "ratio",  nBins, minPt, maxPt,                     false, false, label_PhotonPt,     label_map[tag+"Iso_ratio"], true});
+      plotParamsPhoton.push_back({"Photon", tag+"Iso", "Energy", makePDCPhotonIso_ratio(tag, "E","ratio"),     "ratio",  nBins, minEnergy, maxEnergy,             false, false, label_PhotonEnergy, label_map[tag+"Iso_ratio"], true});
+      plotParamsPhoton.push_back({"Photon", tag+"Iso", "Mass",   makePDCPhotonIso_ratio(tag, "M","ratio"),     "ratio",  nBins, minMassPhoton, maxMassPhoton,     false, false, label_PhotonMass,   label_map[tag+"Iso_ratio"], true});
+      plotParamsPhoton.push_back({"Photon", tag+"Iso", "Eta",    makePDCPhotonIso_ratio(tag, "eta","ratio"),   "ratio",  nBins, minEta, maxEta,                   false, false, label_PhotonEta,    label_map[tag+"Iso_ratio"], true});
+      plotParamsPhoton.push_back({"Photon", tag+"Iso", "Phi",    makePDCPhotonIso_ratio(tag, "phi","ratio"),   "ratio",  nBins, minPhi, maxPhi,                   false, false, label_PhotonPhi,    label_map[tag+"Iso_ratio"], true});
+    }
     
     if (doLeptons)
     {

--- a/Tools/MakePlots.C
+++ b/Tools/MakePlots.C
@@ -662,16 +662,20 @@ int main(int argc, char* argv[])
       plotParamsPhoton.push_back({"Photon", tag+"Match", "Eta",    makePDCPhotonMatch_ratio(tag, "eta","ratio"),   "ratio",  nBins, minEta, maxEta,               false, false, label_PhotonEta,    label_map[tag+"Match_ratio"], true});
       plotParamsPhoton.push_back({"Photon", tag+"Match", "Phi",    makePDCPhotonMatch_ratio(tag, "phi","ratio"),   "ratio",  nBins, minPhi, maxPhi,               false, false, label_PhotonPhi,    label_map[tag+"Match_ratio"], true});
       // Iso
-      plotParamsPhoton.push_back({"Photon", tag+"Iso", "Pt",     makePDCPhotonIso_single(tag, "pt","single"),  "single", nBins, minPt, maxPt,                     true, false,  label_PhotonPt,     label_map[tag+"Iso_single"], true});
-      plotParamsPhoton.push_back({"Photon", tag+"Iso", "Energy", makePDCPhotonIso_single(tag, "E","single"),   "single", nBins, minEnergy, maxEnergy,             true, false,  label_PhotonEnergy, label_map[tag+"Iso_single"], true});
-      plotParamsPhoton.push_back({"Photon", tag+"Iso", "Mass",   makePDCPhotonIso_single(tag, "M","single"),   "single", nBins, minMassPhoton, maxMassPhoton,     false, false, label_PhotonMass,   label_map[tag+"Iso_single"], true});
-      plotParamsPhoton.push_back({"Photon", tag+"Iso", "Eta",    makePDCPhotonIso_single(tag, "eta","single"), "single", nBins, minEta, maxEta,                   false, false, label_PhotonEta,    label_map[tag+"Iso_single"], true});
-      plotParamsPhoton.push_back({"Photon", tag+"Iso", "Phi",    makePDCPhotonIso_single(tag, "phi","single"), "single", nBins, minPhi, maxPhi,                   false, false, label_PhotonPhi,    label_map[tag+"Iso_single"], true});
-      plotParamsPhoton.push_back({"Photon", tag+"Iso", "Pt",     makePDCPhotonIso_ratio(tag, "pt","ratio"),    "ratio",  nBins, minPt, maxPt,                     false, false, label_PhotonPt,     label_map[tag+"Iso_ratio"], true});
-      plotParamsPhoton.push_back({"Photon", tag+"Iso", "Energy", makePDCPhotonIso_ratio(tag, "E","ratio"),     "ratio",  nBins, minEnergy, maxEnergy,             false, false, label_PhotonEnergy, label_map[tag+"Iso_ratio"], true});
-      plotParamsPhoton.push_back({"Photon", tag+"Iso", "Mass",   makePDCPhotonIso_ratio(tag, "M","ratio"),     "ratio",  nBins, minMassPhoton, maxMassPhoton,     false, false, label_PhotonMass,   label_map[tag+"Iso_ratio"], true});
-      plotParamsPhoton.push_back({"Photon", tag+"Iso", "Eta",    makePDCPhotonIso_ratio(tag, "eta","ratio"),   "ratio",  nBins, minEta, maxEta,                   false, false, label_PhotonEta,    label_map[tag+"Iso_ratio"], true});
-      plotParamsPhoton.push_back({"Photon", tag+"Iso", "Phi",    makePDCPhotonIso_ratio(tag, "phi","ratio"),   "ratio",  nBins, minPhi, maxPhi,                   false, false, label_PhotonPhi,    label_map[tag+"Iso_ratio"], true});
+      // only iso for reco
+      if (tag.compare("Reco") == 0)
+      {
+        plotParamsPhoton.push_back({"Photon", tag+"Iso", "Pt",     makePDCPhotonIso_single(tag, "pt","single"),  "single", nBins, minPt, maxPt,                     true, false,  label_PhotonPt,     label_map[tag+"Iso_single"], true});
+        plotParamsPhoton.push_back({"Photon", tag+"Iso", "Energy", makePDCPhotonIso_single(tag, "E","single"),   "single", nBins, minEnergy, maxEnergy,             true, false,  label_PhotonEnergy, label_map[tag+"Iso_single"], true});
+        plotParamsPhoton.push_back({"Photon", tag+"Iso", "Mass",   makePDCPhotonIso_single(tag, "M","single"),   "single", nBins, minMassPhoton, maxMassPhoton,     false, false, label_PhotonMass,   label_map[tag+"Iso_single"], true});
+        plotParamsPhoton.push_back({"Photon", tag+"Iso", "Eta",    makePDCPhotonIso_single(tag, "eta","single"), "single", nBins, minEta, maxEta,                   false, false, label_PhotonEta,    label_map[tag+"Iso_single"], true});
+        plotParamsPhoton.push_back({"Photon", tag+"Iso", "Phi",    makePDCPhotonIso_single(tag, "phi","single"), "single", nBins, minPhi, maxPhi,                   false, false, label_PhotonPhi,    label_map[tag+"Iso_single"], true});
+        plotParamsPhoton.push_back({"Photon", tag+"Iso", "Pt",     makePDCPhotonIso_ratio(tag, "pt","ratio"),    "ratio",  nBins, minPt, maxPt,                     false, false, label_PhotonPt,     label_map[tag+"Iso_ratio"], true});
+        plotParamsPhoton.push_back({"Photon", tag+"Iso", "Energy", makePDCPhotonIso_ratio(tag, "E","ratio"),     "ratio",  nBins, minEnergy, maxEnergy,             false, false, label_PhotonEnergy, label_map[tag+"Iso_ratio"], true});
+        plotParamsPhoton.push_back({"Photon", tag+"Iso", "Mass",   makePDCPhotonIso_ratio(tag, "M","ratio"),     "ratio",  nBins, minMassPhoton, maxMassPhoton,     false, false, label_PhotonMass,   label_map[tag+"Iso_ratio"], true});
+        plotParamsPhoton.push_back({"Photon", tag+"Iso", "Eta",    makePDCPhotonIso_ratio(tag, "eta","ratio"),   "ratio",  nBins, minEta, maxEta,                   false, false, label_PhotonEta,    label_map[tag+"Iso_ratio"], true});
+        plotParamsPhoton.push_back({"Photon", tag+"Iso", "Phi",    makePDCPhotonIso_ratio(tag, "phi","ratio"),   "ratio",  nBins, minPhi, maxPhi,                   false, false, label_PhotonPhi,    label_map[tag+"Iso_ratio"], true});
+      }
     }
     
     if (doLeptons)

--- a/Tools/Makefile
+++ b/Tools/Makefile
@@ -122,31 +122,31 @@ $(ODIR)/%.o : $(TTTSDIR)/%.cpp
 	$(CXX) $(CXXFLAGS) $(CXXDEPFLAGS) -I$(RSDIR) -I$(TTIDIR) -I$(TPIDIR) -I$(TPTDIR) -I$(TTTIDIR) $(INCLUDES) -o $@ -c $<
 
 
-calcEff: $(ODIR)/NTupleReader.o $(ODIR)/SATException.o $(ODIR)/samples.o $(ODIR)/calcEff.o $(ODIR)/PDFUncertainty.o $(ODIR)/RegisterFunctions.o $(ODIR)/Systematic.o $(ODIR)/Plotter.o $(ODIR)/MiniTupleMaker.o $(ODIR)/searchBins.o $(ODIR)/BTagCorrector.o $(ODIR)/BTagCalibrationStandalone.o  $(ODIR)/TaggerUtility.o $(ODIR)/PlotUtility.o $(ODIR)/baselineDef.o $(ODIR)/customize.o $(ODIR)/ISRCorrector.o $(ODIR)/PileupWeights.o
+calcEff: $(ODIR)/NTupleReader.o $(ODIR)/SATException.o $(ODIR)/samples.o $(ODIR)/calcEff.o $(ODIR)/PDFUncertainty.o $(ODIR)/RegisterFunctions.o $(ODIR)/Systematic.o $(ODIR)/Plotter.o $(ODIR)/MiniTupleMaker.o $(ODIR)/searchBins.o $(ODIR)/BTagCalibrationStandalone.o  $(ODIR)/TaggerUtility.o $(ODIR)/PlotUtility.o $(ODIR)/baselineDef.o $(ODIR)/customize.o $(ODIR)/ISRCorrector.o 
 	$(LD) $^ $(LIBS) $(MT2LIB) $(LHAPDFLIB) -o $@
 
 harvestHists: $(ODIR)/harvestHists.o
 	$(LD) $^ $(LIBS) -o $@
 
-makePlots: $(ODIR)/NTupleReader.o $(ODIR)/SATException.o $(ODIR)/samples.o $(ODIR)/Plotter.o $(ODIR)/MakePlots.o $(ODIR)/MiniTupleMaker.o $(ODIR)/PDFUncertainty.o $(ODIR)/RegisterFunctions.o $(ODIR)/Systematic.o $(ODIR)/searchBins.o $(ODIR)/BTagCorrector.o $(ODIR)/BTagCalibrationStandalone.o $(ODIR)/TaggerUtility.o $(ODIR)/PlotUtility.o $(ODIR)/baselineDef.o $(ODIR)/customize.o $(ODIR)/ISRCorrector.o $(ODIR)/PileupWeights.o
+makePlots: $(ODIR)/NTupleReader.o $(ODIR)/SATException.o $(ODIR)/samples.o $(ODIR)/Plotter.o $(ODIR)/MakePlots.o $(ODIR)/MiniTupleMaker.o $(ODIR)/PDFUncertainty.o $(ODIR)/RegisterFunctions.o $(ODIR)/Systematic.o $(ODIR)/searchBins.o $(ODIR)/BTagCalibrationStandalone.o $(ODIR)/TaggerUtility.o $(ODIR)/PlotUtility.o $(ODIR)/baselineDef.o $(ODIR)/customize.o $(ODIR)/ISRCorrector.o 
 	$(LD) $^ $(LIBS) $(MT2LIB) $(LHAPDFLIB) -o $@
 
-makeTopPlots: $(ODIR)/NTupleReader.o $(ODIR)/SATException.o $(ODIR)/samples.o $(ODIR)/Plotter.o $(ODIR)/MakeTopPlots.o $(ODIR)/MiniTupleMaker.o $(ODIR)/PDFUncertainty.o $(ODIR)/RegisterFunctions.o $(ODIR)/Systematic.o $(ODIR)/searchBins.o $(ODIR)/BTagCorrector.o $(ODIR)/BTagCalibrationStandalone.o $(ODIR)/TaggerUtility.o $(ODIR)/PlotUtility.o $(ODIR)/baselineDef.o $(ODIR)/customize.o $(ODIR)/ISRCorrector.o $(ODIR)/PileupWeights.o
+makeTopPlots: $(ODIR)/NTupleReader.o $(ODIR)/SATException.o $(ODIR)/samples.o $(ODIR)/Plotter.o $(ODIR)/MakeTopPlots.o $(ODIR)/MiniTupleMaker.o $(ODIR)/PDFUncertainty.o $(ODIR)/RegisterFunctions.o $(ODIR)/Systematic.o $(ODIR)/searchBins.o $(ODIR)/BTagCalibrationStandalone.o $(ODIR)/TaggerUtility.o $(ODIR)/PlotUtility.o $(ODIR)/baselineDef.o $(ODIR)/customize.o $(ODIR)/ISRCorrector.o 
 	$(LD) $^ $(LIBS) $(MT2LIB) $(LHAPDFLIB) -o $@
 
-makeDYPlots: $(ODIR)/NTupleReader.o $(ODIR)/SATException.o $(ODIR)/samples.o $(ODIR)/Plotter.o $(ODIR)/MakeDYPlots.o $(ODIR)/MiniTupleMaker.o $(ODIR)/PDFUncertainty.o $(ODIR)/RegisterFunctions.o $(ODIR)/Systematic.o $(ODIR)/searchBins.o $(ODIR)/BTagCorrector.o $(ODIR)/BTagCalibrationStandalone.o $(ODIR)/TaggerUtility.o $(ODIR)/PlotUtility.o $(ODIR)/baselineDef.o $(ODIR)/customize.o $(ODIR)/ISRCorrector.o $(ODIR)/PileupWeights.o
+makeDYPlots: $(ODIR)/NTupleReader.o $(ODIR)/SATException.o $(ODIR)/samples.o $(ODIR)/Plotter.o $(ODIR)/MakeDYPlots.o $(ODIR)/MiniTupleMaker.o $(ODIR)/PDFUncertainty.o $(ODIR)/RegisterFunctions.o $(ODIR)/Systematic.o $(ODIR)/searchBins.o $(ODIR)/BTagCalibrationStandalone.o $(ODIR)/TaggerUtility.o $(ODIR)/PlotUtility.o $(ODIR)/baselineDef.o $(ODIR)/customize.o $(ODIR)/ISRCorrector.o 
 	$(LD) $^ $(LIBS) $(MT2LIB) $(LHAPDFLIB) -o $@
 
-makePhotonPlots: $(ODIR)/NTupleReader.o $(ODIR)/SATException.o $(ODIR)/samples.o $(ODIR)/Plotter.o $(ODIR)/MakePhotonPlots.o $(ODIR)/MiniTupleMaker.o $(ODIR)/PDFUncertainty.o $(ODIR)/RegisterFunctions.o $(ODIR)/Systematic.o $(ODIR)/searchBins.o $(ODIR)/BTagCorrector.o $(ODIR)/BTagCalibrationStandalone.o $(ODIR)/TaggerUtility.o $(ODIR)/PlotUtility.o $(ODIR)/baselineDef.o $(ODIR)/customize.o $(ODIR)/ISRCorrector.o $(ODIR)/PileupWeights.o
+makePhotonPlots: $(ODIR)/NTupleReader.o $(ODIR)/SATException.o $(ODIR)/samples.o $(ODIR)/Plotter.o $(ODIR)/MakePhotonPlots.o $(ODIR)/MiniTupleMaker.o $(ODIR)/PDFUncertainty.o $(ODIR)/RegisterFunctions.o $(ODIR)/Systematic.o $(ODIR)/searchBins.o $(ODIR)/BTagCalibrationStandalone.o $(ODIR)/TaggerUtility.o $(ODIR)/PlotUtility.o $(ODIR)/baselineDef.o $(ODIR)/customize.o $(ODIR)/ISRCorrector.o 
 	$(LD) $^ $(LIBS) $(MT2LIB) $(LHAPDFLIB) -o $@
 
-miniMakePlots: $(ODIR)/NTupleReader.o $(ODIR)/SATException.o $(ODIR)/miniTupleSamples.o $(ODIR)/Plotter.o $(ODIR)/MinitupleMakePlots.o $(ODIR)/MiniTupleMaker.o $(ODIR)/PDFUncertainty.o $(ODIR)/RegisterFunctions.o $(ODIR)/Systematic.o $(ODIR)/searchBins.o $(ODIR)/BTagCorrector.o $(ODIR)/BTagCalibrationStandalone.o $(ODIR)/TaggerUtility.o $(ODIR)/PlotUtility.o $(ODIR)/baselineDef.o $(ODIR)/customize.o $(ODIR)/ISRCorrector.o $(ODIR)/PileupWeights.o
+miniMakePlots: $(ODIR)/NTupleReader.o $(ODIR)/SATException.o $(ODIR)/miniTupleSamples.o $(ODIR)/Plotter.o $(ODIR)/MinitupleMakePlots.o $(ODIR)/MiniTupleMaker.o $(ODIR)/PDFUncertainty.o $(ODIR)/RegisterFunctions.o $(ODIR)/Systematic.o $(ODIR)/searchBins.o $(ODIR)/BTagCalibrationStandalone.o $(ODIR)/TaggerUtility.o $(ODIR)/PlotUtility.o $(ODIR)/baselineDef.o $(ODIR)/customize.o $(ODIR)/ISRCorrector.o 
 	$(LD) $^ $(LIBS) $(MT2LIB) $(LHAPDFLIB) -o $@
 
-makeDataMCplots: $(ODIR)/NTupleReader.o $(ODIR)/SATException.o $(ODIR)/samples.o $(ODIR)/Plotter.o $(ODIR)/MakePlots.o $(ODIR)/MiniTupleMaker.o $(ODIR)/PDFUncertainty.o $(ODIR)/RegisterFunctions.o $(ODIR)/Systematic.o $(ODIR)/searchBins.o $(ODIR)/BTagCorrector.o $(ODIR)/BTagCalibrationStandalone.o $(ODIR)/TaggerUtility.o $(ODIR)/PlotUtility.o $(ODIR)/baselineDef.o $(ODIR)/customize.o $(ODIR)/ISRCorrector.o $(ODIR)/PileupWeights.o
+makeDataMCplots: $(ODIR)/NTupleReader.o $(ODIR)/SATException.o $(ODIR)/samples.o $(ODIR)/Plotter.o $(ODIR)/MakePlots.o $(ODIR)/MiniTupleMaker.o $(ODIR)/PDFUncertainty.o $(ODIR)/RegisterFunctions.o $(ODIR)/Systematic.o $(ODIR)/searchBins.o $(ODIR)/BTagCalibrationStandalone.o $(ODIR)/TaggerUtility.o $(ODIR)/PlotUtility.o $(ODIR)/baselineDef.o $(ODIR)/customize.o $(ODIR)/ISRCorrector.o 
 	$(LD) $^ $(LIBS) $(MT2LIB) $(LHAPDFLIB) -o $@
 
-systematics: $(ODIR)/NTupleReader.o $(ODIR)/SATException.o $(ODIR)/miniTupleSamples.o $(ODIR)/Systematic.o  $(ODIR)/Plotter.o $(ODIR)/systematics.o $(ODIR)/MiniTupleMaker.o $(ODIR)/PDFUncertainty.o $(ODIR)/RegisterFunctions.o $(ODIR)/searchBins.o $(ODIR)/BTagCorrector.o $(ODIR)/BTagCalibrationStandalone.o $(ODIR)/TaggerUtility.o $(ODIR)/PlotUtility.o $(ODIR)/baselineDef.o $(ODIR)/customize.o $(ODIR)/ISRCorrector.o $(ODIR)/PileupWeights.o
+systematics: $(ODIR)/NTupleReader.o $(ODIR)/SATException.o $(ODIR)/miniTupleSamples.o $(ODIR)/Systematic.o  $(ODIR)/Plotter.o $(ODIR)/systematics.o $(ODIR)/MiniTupleMaker.o $(ODIR)/PDFUncertainty.o $(ODIR)/RegisterFunctions.o $(ODIR)/searchBins.o $(ODIR)/BTagCalibrationStandalone.o $(ODIR)/TaggerUtility.o $(ODIR)/PlotUtility.o $(ODIR)/baselineDef.o $(ODIR)/customize.o $(ODIR)/ISRCorrector.o 
 	$(LD) $^ $(LIBS) $(MT2LIB) $(LHAPDFLIB) -o $@
 
 nJetWgtSyst: $(ODIR)/NTupleReader.o $(ODIR)/SATException.o $(ODIR)/nJetWgtSyst.o $(ODIR)/miniTupleSamples.o $(ODIR)/searchBins.o $(ODIR)/baselineDef.o $(ODIR)/customize.o
@@ -162,7 +162,7 @@ systplot: $(ODIR)/systplot.o $(ODIR)/SATException.o $(ODIR)/searchBins.o
 	$(LD) $^ $(LIBS) -o $@
 
 # problem
-#plot2d: $(ODIR)/plot2D.o $(ODIR)/NTupleReader.o $(ODIR)/SATException.o $(ODIR)/Plotter.o $(ODIR)/PDFUncertainty.o $(ODIR)/RegisterFunctions.o $(ODIR)/Systematic.o $(ODIR)/samples.o $(ODIR)/MiniTupleMaker.o $(ODIR)/searchBins.o $(ODIR)/BTagCorrector.o $(ODIR)/BTagCalibrationStandalone.o $(ODIR)/TaggerUtility.o $(ODIR)/PlotUtility.o $(ODIR)/baselineDef.o $(ODIR)/customize.o $(ODIR)/ISRCorrector.o $(ODIR)/PileupWeights.o
+#plot2d: $(ODIR)/plot2D.o $(ODIR)/NTupleReader.o $(ODIR)/SATException.o $(ODIR)/Plotter.o $(ODIR)/PDFUncertainty.o $(ODIR)/RegisterFunctions.o $(ODIR)/Systematic.o $(ODIR)/samples.o $(ODIR)/MiniTupleMaker.o $(ODIR)/searchBins.o $(ODIR)/BTagCalibrationStandalone.o $(ODIR)/TaggerUtility.o $(ODIR)/PlotUtility.o $(ODIR)/baselineDef.o $(ODIR)/customize.o $(ODIR)/ISRCorrector.o 
 #	$(LD) $^ $(LIBS) $(MT2LIB) $(LHAPDFLIB) -o $@
 
 beffCalc: $(ODIR)/bTagEfficiencyCalc.o $(ODIR)/NTupleReader.o $(ODIR)/samples.o $(ODIR)/baselineDef.o $(ODIR)/customize.o $(ODIR)/SATException.o
@@ -171,11 +171,11 @@ beffCalc: $(ODIR)/bTagEfficiencyCalc.o $(ODIR)/NTupleReader.o $(ODIR)/samples.o 
 makeSignalHistograms: $(ODIR)/makeSignalHistograms.o $(ODIR)/NTupleReader.o $(ODIR)/SATException.o $(ODIR)/samples.o  $(ODIR)/baselineDef.o $(ODIR)/customize.o
 	$(LD) $^ $(LIBS) $(MT2LIB) -o $@
 
-makeTaggerHistograms: $(ODIR)/makeTaggerHistograms.o $(ODIR)/NTupleReader.o $(ODIR)/SATException.o $(ODIR)/samples.o  $(ODIR)/baselineDef.o $(ODIR)/customize.o $(ODIR)/ISRCorrector.o $(ODIR)/PileupWeights.o $(ODIR)/BTagCorrector.o $(ODIR)/BTagCalibrationStandalone.o $(ODIR)/TaggerUtility.o $(ODIR)/PlotUtility.o
+makeTaggerHistograms: $(ODIR)/makeTaggerHistograms.o $(ODIR)/NTupleReader.o $(ODIR)/SATException.o $(ODIR)/samples.o  $(ODIR)/baselineDef.o $(ODIR)/customize.o $(ODIR)/ISRCorrector.o  $(ODIR)/BTagCalibrationStandalone.o $(ODIR)/TaggerUtility.o $(ODIR)/PlotUtility.o
 	$(LD) $^ $(LIBS) $(MT2LIB) -o $@
 
 # unfortunately we have problems with simpleAnalyzer :-(
-#simpleAnalyzer: $(ODIR)/simpleAnalyzer.o $(ODIR)/NTupleReader.o $(ODIR)/SATException.o $(ODIR)/samples.o  $(ODIR)/baselineDef.o $(ODIR)/customize.o $(ODIR)/ISRCorrector.o $(ODIR)/PileupWeights.o $(ODIR)/BTagCorrector.o $(ODIR)/TTbarCorrector.o $(ODIR)/BTagCalibrationStandalone.o $(ODIR)/TaggerUtility.o $(ODIR)/PlotUtility.o $(ODIR)/rootdict.o
+#simpleAnalyzer: $(ODIR)/simpleAnalyzer.o $(ODIR)/NTupleReader.o $(ODIR)/SATException.o $(ODIR)/samples.o  $(ODIR)/baselineDef.o $(ODIR)/customize.o $(ODIR)/ISRCorrector.o  $(ODIR)/TTbarCorrector.o $(ODIR)/BTagCalibrationStandalone.o $(ODIR)/TaggerUtility.o $(ODIR)/PlotUtility.o $(ODIR)/rootdict.o
 #	$(LD) $^ $(LIBS) $(MT2LIB) -o $@
 
 clean:

--- a/Tools/PhotonTools.h
+++ b/Tools/PhotonTools.h
@@ -62,14 +62,14 @@ namespace PhotonFunctions
   
   bool passPhotonPt(const TLorentzVector& photon){
     const double minPt = 200.0;
-    double perPhotonPt = photon.Pt();
-    return ( perPhotonPt > minPt ); // pt cut
+    const double perPhotonPt = photon.Pt();
+    return (perPhotonPt > minPt); // pt cut
   }
 
   bool passPhotonEta(const TLorentzVector& photon){
     const double maxEta = 2.5;
-    double perPhotonEta = photon.Eta();
-    return ( fabs(perPhotonEta) < maxEta ); // eta cut
+    const double perPhotonEta = photon.Eta();
+    return (fabs(perPhotonEta) < maxEta); // eta cut
   }
 
   bool passPhotonPtEta(const TLorentzVector& photon){
@@ -78,22 +78,19 @@ namespace PhotonFunctions
 
   bool isBarrelECAL(const TLorentzVector& photon){
     const double barrelMax = 1.4442;
-    double perPhotonEta = photon.Eta();
-    return (barrelMax == -1 || fabs(perPhotonEta) <= barrelMax);
+    const double perPhotonEta = photon.Eta();
+    return (fabs(perPhotonEta) < barrelMax);
   }
   
   bool isEndcapECAL(const TLorentzVector& photon){
     const double endcapMin = 1.566, endcapMax = 2.5;
-    double perPhotonEta = photon.Eta();
-    return (endcapMin == -1 || fabs(perPhotonEta) >= endcapMin)
-      || (endcapMax == -1 || fabs(perPhotonEta) <= endcapMax);
+    const double perPhotonEta = photon.Eta();
+    return (fabs(perPhotonEta) > endcapMin && fabs(perPhotonEta) < endcapMax);
   }
   
   bool passPhotonECAL(const TLorentzVector& photon){
-    return (
-                passPhotonPtEta(photon)
-             && (isBarrelECAL(photon) || isEndcapECAL(photon))
-        );
+    return (isBarrelECAL(photon) || isEndcapECAL(photon));
+
    // const double minPt = 200.0, barrelMax = 1.4442, endcapMin = 1.566, endcapMax = 2.5;
    // double perPhotonPt = photon.Pt(), perPhotonEta = photon.Eta();
    // return (

--- a/Tools/PhotonTools.h
+++ b/Tools/PhotonTools.h
@@ -106,6 +106,23 @@ namespace PhotonFunctions
    //        );
   }
   
+  bool isRecoMatched(const TLorentzVector& photon, std::vector<TLorentzVector> recoPhotons)
+  {
+    bool recoMatched = false;
+    double genPt = photon.Pt();
+    for(int i = 0; i < recoPhotons.size(); i++)
+    {
+      double deltaR = ROOT::Math::VectorUtil::DeltaR(photon, recoPhotons[i]);
+      double recoPt = recoPhotons[i].Pt();
+      double ptRatio = genPt / recoPt; 
+      if (ptRatio > 0.5 && ptRatio < 2.0 && deltaR < 0.1)
+      {
+        recoMatched = true;
+        break;
+      }
+    }
+    return recoMatched;
+  }
 
   bool isGenMatched_Method1(const TLorentzVector& photon, std::vector<TLorentzVector> genPhoton){
     double RecoPt = photon.Pt();
@@ -131,8 +148,8 @@ namespace PhotonFunctions
     //if (match) std::cout << "pass"<< std::endl << std::endl;
     //else std::cout << "fake"<< std::endl << std::endl;
       return match;
-    
   }
+
   bool isGenMatched_Method2(const TLorentzVector& photon, std::vector<TLorentzVector> genPhoton){
     bool match = false;
     double dRMin = 999.9;

--- a/Tools/PhotonTools.h
+++ b/Tools/PhotonTools.h
@@ -121,49 +121,49 @@ namespace PhotonFunctions
     return recoMatched;
   }
 
-  bool isGenMatched_Method1(const TLorentzVector& photon, std::vector<TLorentzVector> genPhoton){
+  bool isGenMatched_Method1(const TLorentzVector& photon, std::vector<TLorentzVector> genPhotons){
     double RecoPt = photon.Pt();
-    bool match = false;
+    bool genMatched = false;
     
-    //std::cout << "genPhotons: " << genPhoton.size() << std::endl;
-    for(int i = 0; i < genPhoton.size(); i++){
-      double deltaR = ROOT::Math::VectorUtil::DeltaR(genPhoton[i],photon);
-      double GenPt = genPhoton[i].Pt();
+    //std::cout << "genPhotons: " << genPhotons.size() << std::endl;
+    for(int i = 0; i < genPhotons.size(); i++){
+      double deltaR = ROOT::Math::VectorUtil::DeltaR(genPhotons[i],photon);
+      double GenPt = genPhotons[i].Pt();
       double temp_ratio = GenPt/RecoPt;
       /*
-      std::cout << "igenPhoton: " << i+1 << std::endl;
+      std::cout << "igenPhotons: " << i+1 << std::endl;
       std::cout << "Reco Photon Pt: " << RecoPt << std::endl;
       std::cout<< "Gen Photon Pt: " << GenPt<< std::endl;
       std::cout<< "GenPt/RecoPt: " << temp_ratio << std::endl;
       std::cout << "deltaR: " << deltaR << std::endl;
       */
       if (temp_ratio > 0.5 && temp_ratio < 2.0 && deltaR < 0.1){
-        match = true;
+        genMatched = true;
         break;
       }
     }
-    //if (match) std::cout << "pass"<< std::endl << std::endl;
+    //if (genMatched) std::cout << "pass"<< std::endl << std::endl;
     //else std::cout << "fake"<< std::endl << std::endl;
-      return match;
+    return genMatched;
   }
 
-  bool isGenMatched_Method2(const TLorentzVector& photon, std::vector<TLorentzVector> genPhoton){
-    bool match = false;
+  bool isGenMatched_Method2(const TLorentzVector& photon, std::vector<TLorentzVector> genPhotons){
+    bool genMatched = false;
     double dRMin = 999.9;
-    for (int i = 0; i < genPhoton.size(); i++)
+    for (int i = 0; i < genPhotons.size(); i++)
     {
-      double dR = ROOT::Math::VectorUtil::DeltaR(genPhoton[i],photon);
-      double GenPt = genPhoton[i].Pt();
+      double dR = ROOT::Math::VectorUtil::DeltaR(genPhotons[i],photon);
       if(dR < dRMin)
       {
         dRMin = dR;
       }
       if (dRMin < 0.2)
       {
-        match = true;
+        genMatched = true;
+        break;
       }
     }
-    return match;
+    return genMatched;
   }
 
   bool isDirectPhoton(const TLorentzVector& photon, std::vector<TLorentzVector> genParton){

--- a/Tools/PhotonTools.h
+++ b/Tools/PhotonTools.h
@@ -60,33 +60,20 @@ namespace PhotonConsts
 namespace PhotonFunctions
 {
   
-  bool passPhoton_ECAL(const TLorentzVector& photon){
-    const double minPt = 200.0, barrelMax = 1.4442, endcapMin = 1.566, endcapMax = 2.5;
-    double perPhotonPt = photon.Pt(), perPhotonEta = photon.Eta();
-    return (
-             (minPt == -1 || perPhotonPt > minPt) // pt cut
-             && (barrelMax == -1 || fabs(perPhotonEta) < barrelMax)    // within barrel
-             || (  
-                   (endcapMin == -1 || fabs(perPhotonEta) > endcapMin) // within endcap
-                && (endcapMax == -1 || fabs(perPhotonEta) < endcapMax) // within endcap
-                )
-           );
-  }
-  
-  bool passPhoton_Pt(const TLorentzVector& photon){
+  bool passPhotonPt(const TLorentzVector& photon){
     const double minPt = 200.0;
     double perPhotonPt = photon.Pt();
-    return (perPhotonPt > minPt); // pt cut
+    return ( perPhotonPt > minPt ); // pt cut
   }
 
-  bool passPhoton_PtEta(const TLorentzVector& photon){
-    const double minPt = 200.0;
+  bool passPhotonEta(const TLorentzVector& photon){
     const double maxEta = 2.5;
-    double perPhotonPt = photon.Pt(), perPhotonEta = photon.Eta();
-    return (
-                (perPhotonPt > minPt)         // pt cut
-             && (fabs(perPhotonEta) < maxEta) // eta cut
-           );
+    double perPhotonEta = photon.Eta();
+    return ( fabs(perPhotonEta) < maxEta ); // eta cut
+  }
+
+  bool passPhotonPtEta(const TLorentzVector& photon){
+    return (passPhotonPt(photon) && passPhotonEta(photon));
   }
 
   bool isBarrelECAL(const TLorentzVector& photon){
@@ -101,6 +88,24 @@ namespace PhotonFunctions
     return (endcapMin == -1 || fabs(perPhotonEta) >= endcapMin)
       || (endcapMax == -1 || fabs(perPhotonEta) <= endcapMax);
   }
+  
+  bool passPhotonECAL(const TLorentzVector& photon){
+    return (
+                passPhotonPtEta(photon)
+             && (isBarrelECAL(photon) || isEndcapECAL(photon))
+        );
+   // const double minPt = 200.0, barrelMax = 1.4442, endcapMin = 1.566, endcapMax = 2.5;
+   // double perPhotonPt = photon.Pt(), perPhotonEta = photon.Eta();
+   // return (
+   //          (minPt == -1 || perPhotonPt > minPt) // pt cut
+   //          && (barrelMax == -1 || fabs(perPhotonEta) < barrelMax)    // within barrel
+   //          || (  
+   //                (endcapMin == -1 || fabs(perPhotonEta) > endcapMin) // within endcap
+   //             && (endcapMax == -1 || fabs(perPhotonEta) < endcapMax) // within endcap
+   //             )
+   //        );
+  }
+  
 
   bool isGenMatched_Method1(const TLorentzVector& photon, std::vector<TLorentzVector> genPhoton){
     double RecoPt = photon.Pt();

--- a/Tools/PhotonTools.h
+++ b/Tools/PhotonTools.h
@@ -60,20 +60,22 @@ namespace PhotonConsts
 namespace PhotonFunctions
 {
   
-  bool passPhotonPt(const TLorentzVector& photon){
-    const double minPt = 200.0;
-    const double perPhotonPt = photon.Pt();
-    return (perPhotonPt > minPt); // pt cut
-  }
-
+  // eta cut
   bool passPhotonEta(const TLorentzVector& photon){
     const double maxEta = 2.5;
     const double perPhotonEta = photon.Eta();
-    return (fabs(perPhotonEta) < maxEta); // eta cut
+    return (fabs(perPhotonEta) < maxEta);
   }
 
-  bool passPhotonPtEta(const TLorentzVector& photon){
-    return (passPhotonPt(photon) && passPhotonEta(photon));
+  // pt cut
+  bool passPhotonPt(const TLorentzVector& photon){
+    const double minPt = 200.0;
+    const double perPhotonPt = photon.Pt();
+    return (perPhotonPt > minPt);
+  }
+
+  bool passPhotonEtaPt(const TLorentzVector& photon){
+    return (passPhotonEta(photon) && passPhotonPt(photon));
   }
 
   bool isBarrelECAL(const TLorentzVector& photon){

--- a/Tools/calcEff.C
+++ b/Tools/calcEff.C
@@ -73,8 +73,8 @@ int main(int argc, char* argv[])
     //AnaSamples::SampleSet        ss(sampleloc, lumi);
     //AnaSamples::SampleCollection sc(ss);
     // the new version
-    AnaSamples::SampleSet        ss("sampleSets.txt");
-    AnaSamples::SampleCollection sc("sampleCollections.txt", ss);
+    AnaSamples::SampleSet        ss("sampleSets.cfg");
+    AnaSamples::SampleCollection sc("sampleCollections.cfg", ss);
 
 
     TFile *f = new TFile(filename.c_str(),"RECREATE");

--- a/Tools/calculateEfficiency.py
+++ b/Tools/calculateEfficiency.py
@@ -48,13 +48,19 @@ def calcEff(variables):
     print "Total Efficiency = {0:.4f}: {1:.2f} %".format(total_efficiency, total_efficiency_percent)
 
 if __name__ == "__main__":
-    histogramMap = []
-    histogramMap += [{"gammaLVecGen"                : "MC_PhotonGenAccPt_singlegammaLVecGenptgammaLVecGen(pt)GJets #gamma Gensingle"}]
-    histogramMap += [{"gammaLVecGenEta"             : "MC_PhotonGenAccPt_singlegammaLVecGenEtaptgammaLVecGenEta(pt)GJets #gamma GenEtasingle"}]
-    histogramMap += [{"gammaLVecGenEtaPt"           : "MC_PhotonGenMatchPt_singlegammaLVecGenEtaPtptgammaLVecGenEtaPt(pt)GJets #gamma GenEtaPtsingle"}]
-    histogramMap += [{"gammaLVecGenEtaPtMatched"    : "MC_PhotonGenMatchPt_singlegammaLVecGenEtaPtMatchedptgammaLVecGenEtaPtMatched(pt)GJets #gamma GenEtaPtMatchedsingle"}]
-    histogramMap += [{"gammaLVecGenIso"             : "MC_PhotonGenIsoPt_singlegammaLVecGenIsoptgammaLVecGenIso(pt)GJets #gamma GenIsosingle"}]
-    getResults("result.root", histogramMap)
+    histogramMapGen = []
+    histogramMapGen += [{"gammaLVecGen"                : "MC_PhotonGenAccPt_singlegammaLVecGenptgammaLVecGen(pt)GJets #gamma Gensingle"}]
+    histogramMapGen += [{"gammaLVecGenEta"             : "MC_PhotonGenAccPt_singlegammaLVecGenEtaptgammaLVecGenEta(pt)GJets #gamma GenEtasingle"}]
+    histogramMapGen += [{"gammaLVecGenEtaPt"           : "MC_PhotonGenMatchPt_singlegammaLVecGenEtaPtptgammaLVecGenEtaPt(pt)GJets #gamma GenEtaPtsingle"}]
+    histogramMapGen += [{"gammaLVecGenEtaPtMatched"    : "MC_PhotonGenMatchPt_singlegammaLVecGenEtaPtMatchedptgammaLVecGenEtaPtMatched(pt)GJets #gamma GenEtaPtMatchedsingle"}]
+    histogramMapReco = []
+    histogramMapReco += [{"gammaLVecReco"                : "MC_PhotonRecoAccPt_singlegammaLVecRecoptgammaLVecReco(pt)GJets #gamma Recosingle"}]
+    histogramMapReco += [{"gammaLVecRecoEta"             : "MC_PhotonRecoAccPt_singlegammaLVecRecoEtaptgammaLVecRecoEta(pt)GJets #gamma RecoEtasingle"}]
+    histogramMapReco += [{"gammaLVecRecoEtaPt"           : "MC_PhotonRecoMatchPt_singlegammaLVecRecoEtaPtptgammaLVecRecoEtaPt(pt)GJets #gamma RecoEtaPtsingle"}]
+    histogramMapReco += [{"gammaLVecRecoIso"             : "MC_PhotonRecoIsoPt_singlegammaLVecRecoIsoptgammaLVecRecoIso(pt)GJets #gamma RecoIsosingle"}]
+    histogramMapReco += [{"gammaLVecRecoEtaPtMatched"    : "MC_PhotonRecoMatchPt_singlegammaLVecRecoEtaPtMatchedptgammaLVecRecoEtaPtMatched(pt)GJets #gamma RecoEtaPtMatchedsingle"}]
+    getResults("result.root", histogramMapGen)
+    getResults("result.root", histogramMapReco)
     #calcEff([ 
     #        {"reco":            1 * 10 ** 6}, 
     #        {"eta_cut":         1 * 10 ** 5},

--- a/Tools/calculateEfficiency.py
+++ b/Tools/calculateEfficiency.py
@@ -42,15 +42,18 @@ def calcEff(variables):
         total_efficiency *= ratio
         names = "{0}/{1}".format(b_name, a_name)
         values = "{0:.3E}/{1:.3E}".format(Decimal(b_value), Decimal(a_value))
-        print("{0:30} = {1:20} = {2:10.4f}: {3:10.2f} %".format(names, values, ratio, ratio_percent))
+        print("{0:50} = {1:20} = {2:10.4f}: {3:10.2f} %".format(names, values, ratio, ratio_percent))
         i += 1
     total_efficiency_percent = 100.0 * total_efficiency
     print "Total Efficiency = {0:.4f}: {1:.2f} %".format(total_efficiency, total_efficiency_percent)
 
 if __name__ == "__main__":
     histogramMap = []
-    histogramMap += [{"gammaLVecGen"    : "MC_PhotonGenAccPt_singlegammaLVecGenptgammaLVecGen(pt)GJets #gamma Gensingle"}]
-    histogramMap += [{"gammaLVecGenEta" : "MC_PhotonGenAccPt_singlegammaLVecGenEtaptgammaLVecGenEta(pt)GJets #gamma GenEtasingle"}]
+    histogramMap += [{"gammaLVecGen"                : "MC_PhotonGenAccPt_singlegammaLVecGenptgammaLVecGen(pt)GJets #gamma Gensingle"}]
+    histogramMap += [{"gammaLVecGenEta"             : "MC_PhotonGenAccPt_singlegammaLVecGenEtaptgammaLVecGenEta(pt)GJets #gamma GenEtasingle"}]
+    histogramMap += [{"gammaLVecGenEtaPt"           : "MC_PhotonGenMatchPt_singlegammaLVecGenEtaPtptgammaLVecGenEtaPt(pt)GJets #gamma GenEtaPtsingle"}]
+    histogramMap += [{"gammaLVecGenEtaPtMatched"    : "MC_PhotonGenMatchPt_singlegammaLVecGenEtaPtMatchedptgammaLVecGenEtaPtMatched(pt)GJets #gamma GenEtaPtMatchedsingle"}]
+    histogramMap += [{"gammaLVecGenIso"             : "MC_PhotonGenIsoPt_singlegammaLVecGenIsoptgammaLVecGenIso(pt)GJets #gamma GenIsosingle"}]
     getResults("result.root", histogramMap)
     #calcEff([ 
     #        {"reco":            1 * 10 ** 6}, 
@@ -59,3 +62,6 @@ if __name__ == "__main__":
     #        {"gen_matched":     1 * 10 ** 3},
     #        {"loose_isolation": 1 * 10 ** 2}
     #       ])
+
+
+

--- a/Tools/calculateEfficiency.py
+++ b/Tools/calculateEfficiency.py
@@ -1,0 +1,61 @@
+# calculateEfficiency.py
+# Caleb J. Smith
+# September 19, 2018
+
+# calculate efficiencies
+
+import ROOT
+from decimal import Decimal
+
+# get results given input file and list of histograms
+def getResults(inputFile, histograms):
+    f = ROOT.TFile(inputFile)
+    if not f:
+        print "ERROR: The file {0} did not load".format(inputFile)
+        return
+    nEventsPerHist = []
+    for histogramMap in histograms:
+        #print histogramMap
+        d_name, h_name = histogramMap.items()[0]
+        h = f.Get(d_name + "/" + h_name)
+        #print "directory: {0} ; h: {1}".format(d_name, h)
+        if not h:
+            print "ERROR: The histogram {0} from directory {1} did not load".format(h_name, d_name)
+            return
+        #nEventsPerHist.append({d_name : h.GetEntries()})
+        nEventsPerHist.append({d_name : h.Integral()})
+    #print nEventsPerHist
+    calcEff(nEventsPerHist)
+
+# calculate and print ratios
+def calcEff(variables):
+    i = 0
+    total_efficiency = 1.0
+    #print variables
+    while i < len(variables) - 1: 
+        #print variables[i]
+        # get key (name) and value (value) 
+        a_name, a_value = variables[i].items()[0]
+        b_name, b_value = variables[i+1].items()[0]
+        ratio = float(b_value) / float(a_value)
+        ratio_percent = 100.0 * ratio
+        total_efficiency *= ratio
+        names = "{0}/{1}".format(b_name, a_name)
+        values = "{0:.3E}/{1:.3E}".format(Decimal(b_value), Decimal(a_value))
+        print("{0:30} = {1:20} = {2:10.4f}: {3:10.2f} %".format(names, values, ratio, ratio_percent))
+        i += 1
+    total_efficiency_percent = 100.0 * total_efficiency
+    print "Total Efficiency = {0:.4f}: {1:.2f} %".format(total_efficiency, total_efficiency_percent)
+
+if __name__ == "__main__":
+    histogramMap = []
+    histogramMap += [{"gammaLVecGen"    : "MC_PhotonGenAccPt_singlegammaLVecGenptgammaLVecGen(pt)GJets #gamma Gensingle"}]
+    histogramMap += [{"gammaLVecGenEta" : "MC_PhotonGenAccPt_singlegammaLVecGenEtaptgammaLVecGenEta(pt)GJets #gamma GenEtasingle"}]
+    getResults("result.root", histogramMap)
+    #calcEff([ 
+    #        {"reco":            1 * 10 ** 6}, 
+    #        {"eta_cut":         1 * 10 ** 5},
+    #        {"eta_pt_cut":      1 * 10 ** 4},
+    #        {"gen_matched":     1 * 10 ** 3},
+    #        {"loose_isolation": 1 * 10 ** 2}
+    #       ])

--- a/Tools/condor/processResults.sh
+++ b/Tools/condor/processResults.sh
@@ -106,8 +106,8 @@ rm plots/*
 echo "- Compiling MakePlots"
 make -j8
 
-echo "- Running MakePlots"
-./makePlots -flg -I $resultFile
+echo "- Running MakePlots with -g for photons"
+./makePlots -f -g -I $resultFile
 
 if [[ $? == 0 ]]; then
     echo "  MakePlots was successful"

--- a/Tools/include/Ak8DrMatch.h
+++ b/Tools/include/Ak8DrMatch.h
@@ -40,12 +40,11 @@ namespace plotterFunctions
      private:
          void generateAk8DrMatch(NTupleReader& tr) {
              const auto& jetsLVec           = tr.getVec<TLorentzVector>("jetsLVec");
-             const auto& deepAK8LVec        = tr.getVec<TLorentzVector>("deepAK8LVec");
+             const auto& puppiJetsLVec      = tr.getVec<TLorentzVector>("puppiJetsLVec");
              const auto& puppiLVectight_top = tr.getVec<TLorentzVector>("puppiLVectight_top");
              const auto& puppiLVecLoose_top = tr.getVec<TLorentzVector>("puppiLVecLoose_top");
              const auto& puppiLVectight_w   = tr.getVec<TLorentzVector>("puppiLVectight_w");
              const auto& puppiLVecLoose_w   = tr.getVec<TLorentzVector>("puppiLVecLoose_w");  
-             const auto& puppiJetsLVec      = tr.getVec<TLorentzVector>("puppiJetsLVec");
 
              int nJetsAK41_min = 0;
              int nJetsAK41_med = 0; 
@@ -68,8 +67,8 @@ namespace plotterFunctions
              auto* puppi_top_T_2dRMin = new std::vector<data_t>(); 
              for(int iJet = 0; iJet < jetsLVec.size(); ++iJet)
              {
-                 if(deepAK8LVec.size() >= 1) ak81dRMin->push_back( ROOT::Math::VectorUtil::DeltaR(jetsLVec[iJet], deepAK8LVec[0]));
-                 if(deepAK8LVec.size() >= 2) ak82dRMin->push_back( ROOT::Math::VectorUtil::DeltaR(jetsLVec[iJet], deepAK8LVec[1]));
+                 if(puppiJetsLVec.size() >= 1) ak81dRMin->push_back( ROOT::Math::VectorUtil::DeltaR(jetsLVec[iJet], puppiJetsLVec[0]));
+                 if(puppiJetsLVec.size() >= 2) ak82dRMin->push_back( ROOT::Math::VectorUtil::DeltaR(jetsLVec[iJet], puppiJetsLVec[1]));
                  //if(puppiLVectight_top.size() >= 1) puppi_top_L_1dRMin-> push_back( ROOT::Math::VectorUtil::DeltaR(jetsLVec[iJet], puppiLVectight_top[0]));
                  //if(puppiLVectight_top.size() >= 2) puppi_top_L_2dRMin ->push_back( ROOT::Math::VectorUtil::DeltaR(jetsLVec[iJet], puppiLVectight_top[1]));
                  //if(puppiLVecLoose_top.size() >= 1) puppi_top_T_1dRMin-> push_back( ROOT::Math::VectorUtil::DeltaR(jetsLVec[iJet], puppiLVecLoose_top[0]));

--- a/Tools/include/Gamma.h
+++ b/Tools/include/Gamma.h
@@ -88,7 +88,6 @@ namespace plotterFunctions
         auto* gammaLVecGenEta           = new std::vector<TLorentzVector>(); 
         auto* gammaLVecGenEtaPt         = new std::vector<TLorentzVector>(); 
         auto* gammaLVecGenEtaPtMatched  = new std::vector<TLorentzVector>(); 
-        auto* gammaLVecGenIso           = new std::vector<TLorentzVector>(); 
         auto* gammaLVecReco             = new std::vector<TLorentzVector>();
         auto* gammaLVecRecoEta          = new std::vector<TLorentzVector>();
         auto* gammaLVecRecoEtaPt        = new std::vector<TLorentzVector>();
@@ -117,6 +116,7 @@ namespace plotterFunctions
         //Pass cuts; use some variables from ntuples
         
         //Select gen photons
+        //extraLooseID (photon id and iso) are only for reco photons
         for(int i = 0; i < gammaLVecGen.size(); ++i) {
           // ECAL eta cuts
           if (PhotonFunctions::passPhotonECAL(gammaLVecGen[i]))
@@ -131,12 +131,6 @@ namespace plotterFunctions
             if (PhotonFunctions::isRecoMatched(gammaLVecGen[i], gammaLVec)) 
             {
               gammaLVecGenEtaPtMatched->push_back(gammaLVecGen[i]);
-              //Select iso photons passing passAcc, passIDLoose and passIsoLoose
-              //extraLooseID is only for reco photons
-              if(bool(extraLooseID[i]))
-              {
-                gammaLVecGenIso->push_back(gammaLVecGen[i]);
-              }
             }
           }
         }
@@ -179,15 +173,15 @@ namespace plotterFunctions
           if (PhotonFunctions::passPhotonEtaPt((*gammaLVecRecoEta)[i])) 
           {
             gammaLVecRecoEtaPt->push_back((*gammaLVecRecoEta)[i]);
-            // gen match
-            //if (bool(genMatched[i]))
-            if (PhotonFunctions::isGenMatched_Method1((*gammaLVecRecoEta)[i], gammaLVecGen))
+            //Select iso photons passing passAcc, passIDLoose and passIsoLoose
+            if(bool(extraLooseID[i]))
             {
-              gammaLVecRecoEtaPtMatched->push_back((*gammaLVecRecoEta)[i]);
-              //Select iso photons passing passAcc, passIDLoose and passIsoLoose
-              if(bool(extraLooseID[i]))
+              gammaLVecRecoIso->push_back((*gammaLVecRecoEta)[i]);
+              // gen match
+              //if (PhotonFunctions::isGenMatched_Method1((*gammaLVecRecoEta)[i], gammaLVecGen))
+              if (bool(genMatched[i]))
               {
-                gammaLVecRecoIso->push_back((*gammaLVecRecoEta)[i]);
+                gammaLVecRecoEtaPtMatched->push_back((*gammaLVecRecoEta)[i]);
               }
             }
           }
@@ -240,7 +234,6 @@ namespace plotterFunctions
         tr.registerDerivedVec("gammaLVecGenEta", gammaLVecGenEta);
         tr.registerDerivedVec("gammaLVecGenEtaPt", gammaLVecGenEtaPt);
         tr.registerDerivedVec("gammaLVecGenEtaPtMatched", gammaLVecGenEtaPtMatched);
-        tr.registerDerivedVec("gammaLVecGenIso", gammaLVecGenIso);
         tr.registerDerivedVec("gammaLVecReco", gammaLVecReco);
         tr.registerDerivedVec("gammaLVecRecoEta", gammaLVecRecoEta);
         tr.registerDerivedVec("gammaLVecRecoEtaPt", gammaLVecRecoEtaPt);

--- a/Tools/include/Gamma.h
+++ b/Tools/include/Gamma.h
@@ -80,7 +80,7 @@ namespace plotterFunctions
         const auto& ntops                = tr.getVar<int>("nTopCandSortedCnt");
 
         // toggle debugging print statements
-        bool debug = false;
+        bool debug = true;
 
         //variables to be used in the analysis code
         double photonPtCut = 200.0;
@@ -139,23 +139,14 @@ namespace plotterFunctions
           }
         }
 
-        //Select reco photons; no pt cuts at the moment
+        //Select reco photons; only eta cuts for now
         for(int i = 0; i < gammaLVec.size(); ++i) {
-          // passing pt and eta cuts
-          if (PhotonFunctions::passPhotonEta(gammaLVec[i]))
+          // passing ECAL barrel/endcap eta cuts
+          // this needs to be done prior to any other cuts (pt, gen matched, etc)
+          // this cut should match passAcc which is done in StopTupleMaker/SkimsAUX/plugins/PhotonIDisoProducer.cc
+          if (PhotonFunctions::passPhotonECAL(gammaLVec[i])) 
           {
-            // passing ECAL barrel/endcap eta cuts and reco match
-            // this needs to be done prior to any other cuts (pt, gen matched, etc)
-            // this cut should match passAcc which is done in StopTupleMaker/SkimsAUX/plugins/PhotonIDisoProducer.cc
-            if (PhotonFunctions::passPhotonECAL(gammaLVec[i])) 
-            {
-              gammaLVecRecoAcc->push_back(gammaLVec[i]);
-              //Select iso photons passing passAcc, passIDLoose and passIsoLoose
-              if(bool(extraLooseID[i]))
-              {
-                gammaLVecRecoIso->push_back(gammaLVec[i]);
-              }
-            }
+            gammaLVecRecoAcc->push_back(gammaLVec[i]);
           }
         }
         

--- a/Tools/include/Gamma.h
+++ b/Tools/include/Gamma.h
@@ -99,15 +99,15 @@ namespace plotterFunctions
         
         //Select gen photons passing pt and eta cuts 
         for(int i = 0; i < gammaLVecGen.size(); ++i) {
-          if (PhotonFunctions::passPhoton_Pt(gammaLVecGen[i]))    gammaLVecGenPtCut->push_back(gammaLVecGen[i]);
-          if (PhotonFunctions::passPhoton_PtEta(gammaLVecGen[i])) gammaLVecGenAcc->push_back(gammaLVecGen[i]);
+          if (PhotonFunctions::passPhotonPt(gammaLVecGen[i]))    gammaLVecGenPtCut->push_back(gammaLVecGen[i]);
+          if (PhotonFunctions::passPhotonPtEta(gammaLVecGen[i])) gammaLVecGenAcc->push_back(gammaLVecGen[i]);
         }
 
         //Select reco photons within the ECAL acceptance region and Pt > 200 GeV 
         for(int i = 0; i < gammaLVec.size(); ++i) {
           if (   
-                 PhotonFunctions::passPhoton_PtEta(gammaLVec[i])
-              && PhotonFunctions::passPhoton_ECAL(gammaLVec[i])
+                 PhotonFunctions::passPhotonPtEta(gammaLVec[i])
+              && PhotonFunctions::passPhotonECAL(gammaLVec[i])
               && bool(genMatched[i])
               ) 
           {

--- a/Tools/include/Gamma.h
+++ b/Tools/include/Gamma.h
@@ -132,6 +132,7 @@ namespace plotterFunctions
             {
               gammaLVecGenEtaPtMatched->push_back(gammaLVecGen[i]);
               //Select iso photons passing passAcc, passIDLoose and passIsoLoose
+              //extraLooseID is only for reco photons
               if(bool(extraLooseID[i]))
               {
                 gammaLVecGenIso->push_back(gammaLVecGen[i]);

--- a/Tools/include/Gamma.h
+++ b/Tools/include/Gamma.h
@@ -79,6 +79,9 @@ namespace plotterFunctions
         const auto& nbJets               = tr.getVar<int>("cntCSVS");
         const auto& ntops                = tr.getVar<int>("nTopCandSortedCnt");
 
+        // toggle debugging print statements
+        bool debug = false;
+
         //variables to be used in the analysis code
         double photonPtCut = 200.0;
         double photonMet = -999.9;
@@ -142,6 +145,8 @@ namespace plotterFunctions
           if (PhotonFunctions::passPhotonEta(gammaLVec[i]))
           {
             // passing ECAL barrel/endcap eta cuts and reco match
+            // this needs to be done prior to any other cuts (pt, gen matched, etc)
+            // this cut should match passAcc which is done in StopTupleMaker/SkimsAUX/plugins/PhotonIDisoProducer.cc
             if (PhotonFunctions::passPhotonECAL(gammaLVec[i])) 
             {
               gammaLVecRecoAcc->push_back(gammaLVec[i]);
@@ -161,9 +166,10 @@ namespace plotterFunctions
         if (gammaLVecRecoAcc->size() != loosePhotonID.size())   passed = false;
         if (gammaLVecRecoAcc->size() != mediumPhotonID.size())  passed = false;
         if (gammaLVecRecoAcc->size() != tightPhotonID.size())   passed = false;
-        printf("gen reco genMatched extraLooseID loosePhotonID mediumPhotonID tightPhotonID: %d %d --- %d %d %d %d %d --- %s\n", \
-          int(gammaLVecGen.size()), int(gammaLVecRecoAcc->size()), int(genMatched.size()), int(extraLooseID.size()),      \
-          int(loosePhotonID.size()), int(mediumPhotonID.size()), int(tightPhotonID.size()), passed ? "pass" : "fail");
+        if (debug) // print debugging statements
+          printf("gen reco genMatched extraLooseID loosePhotonID mediumPhotonID tightPhotonID: %d %d --- %d %d %d %d %d --- %s\n", \
+            int(gammaLVecGen.size()), int(gammaLVecRecoAcc->size()), int(genMatched.size()), int(extraLooseID.size()),      \
+            int(loosePhotonID.size()), int(mediumPhotonID.size()), int(tightPhotonID.size()), passed ? "pass" : "fail");
 
         //Select reco photons within the ECAL acceptance region and Pt > 200 GeV 
         for(int i = 0; i < gammaLVec.size(); ++i) {

--- a/Tools/include/Gamma.h
+++ b/Tools/include/Gamma.h
@@ -98,12 +98,11 @@ namespace plotterFunctions
         auto* totalPhotons              = new std::vector<TLorentzVector>();
 
         // check vector lengths
-        std::string message = "";
-        if (gammaLVec.size() == extraLooseID.size())
-          message = "pass";
-        else
-          message = "fail";
-        printf("sizes: %d %d %d --- %s\n", int(gammaLVecGen.size()), int(gammaLVec.size()), int(extraLooseID.size()), message.c_str());
+        bool passed = false;
+        if (gammaLVec.size() == genMatched.size() && gammaLVec.size() == extraLooseID.size())
+          passed = true;
+        printf("gen reco genMatched extraLooseID: %d %d %d %d --- %s\n", int(gammaLVecGen.size()), int(gammaLVec.size()), \
+                                                                         int(genMatched.size()), int(extraLooseID.size()), passed ? "pass" : "fail");
         //Pass cuts; use some variables from ntuples
         
         //Select gen photons

--- a/Tools/include/Gamma.h
+++ b/Tools/include/Gamma.h
@@ -177,7 +177,8 @@ namespace plotterFunctions
           if (PhotonFunctions::passPhotonPtEta((*gammaLVecRecoEta)[i])) 
           {
             gammaLVecRecoEtaPt->push_back((*gammaLVecRecoEta)[i]);
-            if (bool(genMatched[i]))
+            //if (bool(genMatched[i]))
+            if (PhotonFunctions::isGenMatched_Method1((*gammaLVecRecoEta)[i], gammaLVecGen))
             {
               gammaLVecRecoEtaPtMatched->push_back((*gammaLVecRecoEta)[i]);
               //Select iso photons passing passAcc, passIDLoose and passIsoLoose

--- a/Tools/include/Gamma.h
+++ b/Tools/include/Gamma.h
@@ -85,10 +85,11 @@ namespace plotterFunctions
         //variables to be used in the analysis code
         double photonPtCut = 200.0;
         double photonMet = -999.9;
-        auto* gammaLVecGenPt            = new std::vector<TLorentzVector>(); 
+        auto* gammaLVecGenEta           = new std::vector<TLorentzVector>(); 
         auto* gammaLVecGenEtaPt         = new std::vector<TLorentzVector>(); 
-        auto* gammaLVecGenRecoMatched   = new std::vector<TLorentzVector>(); 
+        auto* gammaLVecGenEtaPtMatched  = new std::vector<TLorentzVector>(); 
         auto* gammaLVecGenIso           = new std::vector<TLorentzVector>(); 
+        auto* gammaLVecReco             = new std::vector<TLorentzVector>();
         auto* gammaLVecRecoEta          = new std::vector<TLorentzVector>();
         auto* gammaLVecRecoEtaPt        = new std::vector<TLorentzVector>();
         auto* gammaLVecRecoEtaPtMatched = new std::vector<TLorentzVector>();
@@ -117,25 +118,23 @@ namespace plotterFunctions
         
         //Select gen photons
         for(int i = 0; i < gammaLVecGen.size(); ++i) {
-          // passing pt cut
-          if (PhotonFunctions::passPhotonPt(gammaLVecGen[i]))
+          // ECAL eta cuts
+          if (PhotonFunctions::passPhotonECAL(gammaLVecGen[i]))
           {
-            gammaLVecGenPt->push_back(gammaLVecGen[i]);
+            gammaLVecGenEta->push_back(gammaLVecGen[i]);
           }
           // passing pt and eta cuts
-          if (PhotonFunctions::passPhotonPtEta(gammaLVecGen[i]))
+          if (PhotonFunctions::passPhotonEtaPt(gammaLVecGen[i]))
           {
             gammaLVecGenEtaPt->push_back(gammaLVecGen[i]);
             // passing ECAL barrel/endcap eta cuts and reco match
-            if (  PhotonFunctions::passPhotonECAL(gammaLVecGen[i])
-               && bool(PhotonFunctions::isRecoMatched(gammaLVecGen[i], gammaLVec))
-               ) 
+            if (PhotonFunctions::isRecoMatched(gammaLVecGen[i], gammaLVec)) 
             {
-              gammaLVecGenRecoMatched->push_back(gammaLVec[i]);
+              gammaLVecGenEtaPtMatched->push_back(gammaLVecGen[i]);
               //Select iso photons passing passAcc, passIDLoose and passIsoLoose
               if(bool(extraLooseID[i]))
               {
-                gammaLVecGenIso->push_back(gammaLVec[i]);
+                gammaLVecGenIso->push_back(gammaLVecGen[i]);
               }
             }
           }
@@ -143,6 +142,7 @@ namespace plotterFunctions
 
         //Select reco photons; only eta cuts for now
         for(int i = 0; i < gammaLVec.size(); ++i) {
+            gammaLVecReco->push_back(gammaLVec[i]);
           // passing ECAL barrel/endcap eta cuts
           // this needs to be done prior to any other cuts (pt, gen matched, etc)
           // this cut should match passAcc which is done in StopTupleMaker/SkimsAUX/plugins/PhotonIDisoProducer.cc
@@ -174,9 +174,11 @@ namespace plotterFunctions
         //Select reco photons within the ECAL acceptance region and Pt > 200 GeV 
         for(int i = 0; i < gammaLVecRecoEta->size(); ++i)
         {
-          if (PhotonFunctions::passPhotonPtEta((*gammaLVecRecoEta)[i])) 
+          // pt and eta cuts
+          if (PhotonFunctions::passPhotonEtaPt((*gammaLVecRecoEta)[i])) 
           {
             gammaLVecRecoEtaPt->push_back((*gammaLVecRecoEta)[i]);
+            // gen match
             //if (bool(genMatched[i]))
             if (PhotonFunctions::isGenMatched_Method1((*gammaLVecRecoEta)[i], gammaLVecGen))
             {
@@ -234,10 +236,11 @@ namespace plotterFunctions
         tr.registerDerivedVar("passPrompt", promptPhotons->size() >= 1);
         tr.registerDerivedVar("passDirect", directPhotons->size() >= 1);
         tr.registerDerivedVar("passFragmentation", fragmentationQCD->size() >= 1);
-        tr.registerDerivedVec("gammaLVecGenPt", gammaLVecGenPt);
+        tr.registerDerivedVec("gammaLVecGenEta", gammaLVecGenEta);
         tr.registerDerivedVec("gammaLVecGenEtaPt", gammaLVecGenEtaPt);
-        tr.registerDerivedVec("gammaLVecGenRecoMatched", gammaLVecGenRecoMatched);
+        tr.registerDerivedVec("gammaLVecGenEtaPtMatched", gammaLVecGenEtaPtMatched);
         tr.registerDerivedVec("gammaLVecGenIso", gammaLVecGenIso);
+        tr.registerDerivedVec("gammaLVecReco", gammaLVecReco);
         tr.registerDerivedVec("gammaLVecRecoEta", gammaLVecRecoEta);
         tr.registerDerivedVec("gammaLVecRecoEtaPt", gammaLVecRecoEtaPt);
         tr.registerDerivedVec("gammaLVecRecoEtaPtMatched", gammaLVecRecoEtaPtMatched);

--- a/Tools/include/Gamma.h
+++ b/Tools/include/Gamma.h
@@ -85,8 +85,8 @@ namespace plotterFunctions
         //variables to be used in the analysis code
         double photonPtCut = 200.0;
         double photonMet = -999.9;
-        auto* gammaLVecGenPtCut         = new std::vector<TLorentzVector>(); 
-        auto* gammaLVecGenAcc           = new std::vector<TLorentzVector>(); 
+        auto* gammaLVecGenPt            = new std::vector<TLorentzVector>(); 
+        auto* gammaLVecGenEtaPt         = new std::vector<TLorentzVector>(); 
         auto* gammaLVecGenRecoMatched   = new std::vector<TLorentzVector>(); 
         auto* gammaLVecGenIso           = new std::vector<TLorentzVector>(); 
         auto* gammaLVecRecoEta          = new std::vector<TLorentzVector>();
@@ -120,12 +120,12 @@ namespace plotterFunctions
           // passing pt cut
           if (PhotonFunctions::passPhotonPt(gammaLVecGen[i]))
           {
-            gammaLVecGenPtCut->push_back(gammaLVecGen[i]);
+            gammaLVecGenPt->push_back(gammaLVecGen[i]);
           }
           // passing pt and eta cuts
           if (PhotonFunctions::passPhotonPtEta(gammaLVecGen[i]))
           {
-            gammaLVecGenAcc->push_back(gammaLVecGen[i]);
+            gammaLVecGenEtaPt->push_back(gammaLVecGen[i]);
             // passing ECAL barrel/endcap eta cuts and reco match
             if (  PhotonFunctions::passPhotonECAL(gammaLVecGen[i])
                && bool(PhotonFunctions::isRecoMatched(gammaLVecGen[i], gammaLVec))
@@ -233,10 +233,12 @@ namespace plotterFunctions
         tr.registerDerivedVar("passPrompt", promptPhotons->size() >= 1);
         tr.registerDerivedVar("passDirect", directPhotons->size() >= 1);
         tr.registerDerivedVar("passFragmentation", fragmentationQCD->size() >= 1);
-        tr.registerDerivedVec("gammaLVecGenAcc", gammaLVecGenAcc);
+        tr.registerDerivedVec("gammaLVecGenPt", gammaLVecGenPt);
+        tr.registerDerivedVec("gammaLVecGenEtaPt", gammaLVecGenEtaPt);
         tr.registerDerivedVec("gammaLVecGenRecoMatched", gammaLVecGenRecoMatched);
         tr.registerDerivedVec("gammaLVecGenIso", gammaLVecGenIso);
         tr.registerDerivedVec("gammaLVecRecoEta", gammaLVecRecoEta);
+        tr.registerDerivedVec("gammaLVecRecoEtaPt", gammaLVecRecoEtaPt);
         tr.registerDerivedVec("gammaLVecRecoEtaPtMatched", gammaLVecRecoEtaPtMatched);
         tr.registerDerivedVec("gammaLVecRecoIso", gammaLVecRecoIso);
         tr.registerDerivedVec("cutPhotons", loosePhotons);

--- a/Tools/include/NJetAk8.h
+++ b/Tools/include/NJetAk8.h
@@ -41,10 +41,8 @@ namespace plotterFunctions
     private:
         void generateNJetAk8(NTupleReader& tr)
         {
-            const auto& deepAK8LVec  = tr.getVec<TLorentzVector>("deepAK8LVec"); 
-            const auto& puppiJetsLVec  = tr.getVec<TLorentzVector>("puppiJetsLVec");
-            // const int& nJetsAk8 = deepAK8LVec.size();
-            // const int& nJetsPuppi = puppiJetsLVec.size();
+            const auto& puppiJetsLVec  = tr.getVec<TLorentzVector>("puppiJetsLVec"); 
+            // const int& nJetsAk8 = puppiJetsLVec.size();
             //tr.registerDerivedVar("nJetsAk8", nJetsAk8);
             //tr.registerDerivedVar("nJetsPuppi", nJetsPuppi);
         }

--- a/Tools/include/Taudiv.h
+++ b/Tools/include/Taudiv.h
@@ -49,7 +49,6 @@ namespace plotterFunctions
           //const auto& softDropMass          = tr.getVec<data_t>("softDropMass"); // variable not produced in CMSSW8028_2016 ntuples
           const auto& puppisoftDropMass     = tr.getVec<data_t>("puppisoftDropMass");
           const auto& jetsLVec              = tr.getVec<TLorentzVector>("jetsLVec");
-          const auto& deepAK8LVec           = tr.getVec<TLorentzVector>("deepAK8LVec");
           const auto& puppiJetsLVec         = tr.getVec<TLorentzVector>("puppiJetsLVec");
           const auto& genDecayLVec          = tr.getVec<TLorentzVector>("genDecayLVec");
           const auto& genDecayPdgIdVec      = tr.getVec<int>("genDecayPdgIdVec");
@@ -88,7 +87,7 @@ namespace plotterFunctions
           //std::cout<<"Dijet: " << diJet<<std::endl;
           //std::cout<<"Trijet: " << triJet<<std::endl;
           
-          const int& nJetsAk8 = deepAK8LVec.size(); 
+          const int& nJetsAk8 = puppiJetsLVec.size(); 
           const int& nJetsPuppi = puppiJetsLVec.size();
           tr.registerDerivedVar("nJetsAk8", nJetsAk8);
           tr.registerDerivedVar("nJetsPuppi", nJetsPuppi);
@@ -96,9 +95,9 @@ namespace plotterFunctions
           tr.registerDerivedVar("typeDi",diJet);
           tr.registerDerivedVar("typeTri",triJet);
           
-          //for(unsigned int i=1; i< deepAK8LVec.size(); i++){
+          //for(unsigned int i=1; i< puppiJetsLVec.size(); i++){
           //std::cout<<"AK8 size "<<njetsAk8 << std::endl;
-          //std::cout<<"AK8 pt "<<deepAK8LVec[i].Pt() << std::endl;
+          //std::cout<<"AK8 pt "<<puppiJetsLVec[i].Pt() << std::endl;
           //}
            
           if(puppitau2.size()!=0 && puppitau1.size()!=0 && puppitau2.size()==puppitau1.size()){


### PR DESCRIPTION
- New structure for calculating efficiencies and purities (the order is important)
  - 1: Apply Eta and Pt cuts (both gen and reco)
  - 2: Apply Isolation (for reco photons only)
  - 3: Do matching (require that gen is reco matched or that reco is gen matched)
- New script for calculating efficiencies and purities
  - take ratio of integral of histograms after consecutive cuts