### PR TITLE
libPNG error fix

### DIFF
--- a/Tools/Makefile
+++ b/Tools/Makefile
@@ -44,7 +44,7 @@ INCLUDES += -I$(ZINVISIBLE)/Tools/include
 
 CXXFLAGS += -DDOTENSORFLOWPYBIND
 
-LIBS       = $(shell root-config --glibs)
+LIBS       = $(shell root-config --glibs) -lASImage
 MT2LIB     = -L$(shell $(PYTHONCFG) --prefix)/lib $(shell $(PYTHONCFG) --libs) -L$(TTTDIR) -lTopTagger
 LHAPDFLIB  = -L$(LHAPDF_DATA_PATH)/../../lib -lLHAPDF
 


### PR DESCRIPTION
Added libASImage to the libraries to link against when building.  This solves the problem we had been seeing when trying to save plots to PNG.