### PR TITLE
Speed up unit bin selection

### DIFF
--- a/Tools/Makefile
+++ b/Tools/Makefile
@@ -24,8 +24,10 @@ JSONDIR    = ${CMSSW_BASE}/src/json
 CXX        = g++
 
 CXXFLAGS  += -I. -I$(CMSSW_BASE)/src -std=c++0x -I$(LHAPDF_DATA_PATH)/../../include
-## Optimization flag
-CXXFLAGS += -g -O3
+## Optimization flag: O3
+## Debug flag: -g
+#CXXFLAGS += -g -O3
+CXXFLAGS += -O3
 ## Enable the maximun warning
 #CXXFLAGS += -Wall -Wextra -Weffc++ -g
 

--- a/Tools/Makefile
+++ b/Tools/Makefile
@@ -25,7 +25,7 @@ CXX        = g++
 
 CXXFLAGS  += -I. -I$(CMSSW_BASE)/src -std=c++0x -I$(LHAPDF_DATA_PATH)/../../include
 ## Optimization flag
-CXXFLAGS += -g #-O3
+CXXFLAGS += -g -O3
 ## Enable the maximun warning
 #CXXFLAGS += -Wall -Wextra -Weffc++ -g
 
@@ -118,22 +118,22 @@ $(ODIR)/%.o : $(TTTSDIR)/%.cpp
 	$(CXX) $(CXXFLAGS) $(CXXDEPFLAGS) -I$(RSDIR) -I$(TTIDIR) -I$(TPIDIR) -I$(TPTDIR) -I$(TTTIDIR) $(INCLUDES) -o $@ -c $<
 
 
-calcEff: $(ODIR)/NTupleReader.o $(ODIR)/SATException.o $(ODIR)/samples.o $(ODIR)/calcEff.o $(ODIR)/PDFUncertainty.o $(ODIR)/RegisterFunctions.o $(ODIR)/Systematic.o $(ODIR)/Plotter.o $(ODIR)/MiniTupleMaker.o $(ODIR)/searchBins.o $(ODIR)/BTagCalibrationStandalone.o  $(ODIR)/TaggerUtility.o $(ODIR)/PlotUtility.o $(ODIR)/SusyUtility.o $(ODIR)/baselineDef.o $(ODIR)/customize.o $(ODIR)/ISRCorrector.o 
+calcEff: $(ODIR)/NTupleReader.o $(ODIR)/SATException.o $(ODIR)/samples.o $(ODIR)/calcEff.o $(ODIR)/PDFUncertainty.o $(ODIR)/units.o $(ODIR)/RegisterFunctions.o $(ODIR)/Systematic.o $(ODIR)/Plotter.o $(ODIR)/MiniTupleMaker.o $(ODIR)/searchBins.o $(ODIR)/BTagCalibrationStandalone.o  $(ODIR)/TaggerUtility.o $(ODIR)/PlotUtility.o $(ODIR)/SusyUtility.o $(ODIR)/baselineDef.o $(ODIR)/customize.o $(ODIR)/ISRCorrector.o 
 	$(LD) $^ $(LIBS) $(MT2LIB) $(LHAPDFLIB) -o $@
 
-calcEffPhoton: $(ODIR)/NTupleReader.o $(ODIR)/SATException.o $(ODIR)/samples.o $(ODIR)/calcEffPhoton.o $(ODIR)/PDFUncertainty.o $(ODIR)/RegisterFunctions.o $(ODIR)/Systematic.o $(ODIR)/Plotter.o $(ODIR)/MiniTupleMaker.o $(ODIR)/searchBins.o $(ODIR)/BTagCalibrationStandalone.o  $(ODIR)/TaggerUtility.o $(ODIR)/PlotUtility.o $(ODIR)/SusyUtility.o $(ODIR)/baselineDef.o $(ODIR)/customize.o $(ODIR)/ISRCorrector.o 
+calcEffPhoton: $(ODIR)/NTupleReader.o $(ODIR)/SATException.o $(ODIR)/samples.o $(ODIR)/calcEffPhoton.o $(ODIR)/PDFUncertainty.o $(ODIR)/units.o $(ODIR)/RegisterFunctions.o $(ODIR)/Systematic.o $(ODIR)/Plotter.o $(ODIR)/MiniTupleMaker.o $(ODIR)/searchBins.o $(ODIR)/BTagCalibrationStandalone.o  $(ODIR)/TaggerUtility.o $(ODIR)/PlotUtility.o $(ODIR)/SusyUtility.o $(ODIR)/baselineDef.o $(ODIR)/customize.o $(ODIR)/ISRCorrector.o 
 	$(LD) $^ $(LIBS) $(MT2LIB) $(LHAPDFLIB) -o $@
 
 harvestHists: $(ODIR)/harvestHists.o
 	$(LD) $^ $(LIBS) -o $@
 
-makePlots: $(ODIR)/NTupleReader.o $(ODIR)/SATException.o $(ODIR)/samples.o $(ODIR)/Plotter.o $(ODIR)/MakePlots.o $(ODIR)/MiniTupleMaker.o $(ODIR)/PDFUncertainty.o $(ODIR)/RegisterFunctions.o $(ODIR)/Systematic.o $(ODIR)/searchBins.o $(ODIR)/BTagCalibrationStandalone.o $(ODIR)/TaggerUtility.o $(ODIR)/PlotUtility.o $(ODIR)/SusyUtility.o $(ODIR)/baselineDef.o $(ODIR)/customize.o $(ODIR)/ISRCorrector.o 
+makePlots: $(ODIR)/NTupleReader.o $(ODIR)/SATException.o $(ODIR)/samples.o $(ODIR)/Plotter.o $(ODIR)/MakePlots.o $(ODIR)/MiniTupleMaker.o $(ODIR)/PDFUncertainty.o $(ODIR)/units.o $(ODIR)/RegisterFunctions.o $(ODIR)/Systematic.o $(ODIR)/searchBins.o $(ODIR)/BTagCalibrationStandalone.o $(ODIR)/TaggerUtility.o $(ODIR)/PlotUtility.o $(ODIR)/SusyUtility.o $(ODIR)/baselineDef.o $(ODIR)/customize.o $(ODIR)/ISRCorrector.o 
 	$(LD) $^ $(LIBS) $(MT2LIB) $(LHAPDFLIB) -o $@
 
-miniMakePlots: $(ODIR)/NTupleReader.o $(ODIR)/SATException.o $(ODIR)/miniTupleSamples.o $(ODIR)/Plotter.o $(ODIR)/MinitupleMakePlots.o $(ODIR)/MiniTupleMaker.o $(ODIR)/PDFUncertainty.o $(ODIR)/RegisterFunctions.o $(ODIR)/Systematic.o $(ODIR)/searchBins.o $(ODIR)/BTagCalibrationStandalone.o $(ODIR)/TaggerUtility.o $(ODIR)/PlotUtility.o $(ODIR)/SusyUtility.o $(ODIR)/baselineDef.o $(ODIR)/customize.o $(ODIR)/ISRCorrector.o 
+miniMakePlots: $(ODIR)/NTupleReader.o $(ODIR)/SATException.o $(ODIR)/miniTupleSamples.o $(ODIR)/Plotter.o $(ODIR)/MinitupleMakePlots.o $(ODIR)/MiniTupleMaker.o $(ODIR)/PDFUncertainty.o $(ODIR)/units.o $(ODIR)/RegisterFunctions.o $(ODIR)/Systematic.o $(ODIR)/searchBins.o $(ODIR)/BTagCalibrationStandalone.o $(ODIR)/TaggerUtility.o $(ODIR)/PlotUtility.o $(ODIR)/SusyUtility.o $(ODIR)/baselineDef.o $(ODIR)/customize.o $(ODIR)/ISRCorrector.o 
 	$(LD) $^ $(LIBS) $(MT2LIB) $(LHAPDFLIB) -o $@
 
-systematics: $(ODIR)/NTupleReader.o $(ODIR)/SATException.o $(ODIR)/miniTupleSamples.o $(ODIR)/Systematic.o  $(ODIR)/Plotter.o $(ODIR)/systematics.o $(ODIR)/MiniTupleMaker.o $(ODIR)/PDFUncertainty.o $(ODIR)/RegisterFunctions.o $(ODIR)/searchBins.o $(ODIR)/BTagCalibrationStandalone.o $(ODIR)/TaggerUtility.o $(ODIR)/PlotUtility.o $(ODIR)/SusyUtility.o $(ODIR)/baselineDef.o $(ODIR)/customize.o $(ODIR)/ISRCorrector.o 
+systematics: $(ODIR)/NTupleReader.o $(ODIR)/SATException.o $(ODIR)/miniTupleSamples.o $(ODIR)/Systematic.o  $(ODIR)/Plotter.o $(ODIR)/systematics.o $(ODIR)/MiniTupleMaker.o $(ODIR)/PDFUncertainty.o $(ODIR)/units.o $(ODIR)/RegisterFunctions.o $(ODIR)/searchBins.o $(ODIR)/BTagCalibrationStandalone.o $(ODIR)/TaggerUtility.o $(ODIR)/PlotUtility.o $(ODIR)/SusyUtility.o $(ODIR)/baselineDef.o $(ODIR)/customize.o $(ODIR)/ISRCorrector.o 
 	$(LD) $^ $(LIBS) $(MT2LIB) $(LHAPDFLIB) -o $@
 
 nJetWgtSyst: $(ODIR)/NTupleReader.o $(ODIR)/SATException.o $(ODIR)/nJetWgtSyst.o $(ODIR)/miniTupleSamples.o $(ODIR)/searchBins.o $(ODIR)/baselineDef.o $(ODIR)/customize.o

--- a/Tools/Plotter.cc
+++ b/Tools/Plotter.cc
@@ -463,7 +463,7 @@ void Plotter::createHistsFromTuple()
 
                 registerfunc_->registerFunctions(tr);
                 // skip to event
-                //int myEvent = 550000;
+                //int myEvent = 635000;
                 //std::cout << "Before go to event " << myEvent << std::endl;
                 //tr.goToEvent(myEvent);
                 //std::cout << "After go to event " << myEvent << std::endl;

--- a/Tools/Plotter.cc
+++ b/Tools/Plotter.cc
@@ -658,7 +658,7 @@ bool Plotter::Cut::passCut(const NTupleReader& tr, const int index) const
     }
 }
 
-template<> const double& Plotter::getVarFromVec<TLorentzVector, double>(const VarName& name, const NTupleReader& tr, const int index)
+template<> const double Plotter::getVarFromVec<TLorentzVector, double>(const VarName& name, const NTupleReader& tr, const int index)
 {
     const auto& vec = tr.getVec<TLorentzVector>(name.name);
 

--- a/Tools/Plotter.h
+++ b/Tools/Plotter.h
@@ -218,7 +218,7 @@ private:
     void fillHist(TH1 * const h, const VarName& name, const NTupleReader& tr, const double weight);
     void smartMax(const TH1* const h, const TLegend* const l, const TPad* const p, double& gmin, double& gmax, double& gpThreshMax, const bool error = false) const;
 
-    template<typename T> static const double& tlvGetValue(const std::string& name, const T& v)
+    template<typename T> static const double tlvGetValue(const std::string& name, const T& v)
     {
         if     (name.find("pt")  != std::string::npos)
         {
@@ -279,7 +279,7 @@ private:
         {
             if(name.index >= 0)
             {
-                auto& var = getVarFromVec<T>(name, tr);
+                auto var = getVarFromVec<T>(name, tr);
                 if(&var != nullptr) vectorFill(h, name, pointerDeref(var), weight);
             }
             else
@@ -302,7 +302,7 @@ private:
         }
     }
 
-    template<typename T, typename R = T> static const R& getVarFromVec(const VarName& name, const NTupleReader& tr, const int index = -999)
+    template<typename T, typename R = T> static const R getVarFromVec(const VarName& name, const NTupleReader& tr, const int index = -999)
     {
         const auto& vec = tr.getVec<T>(name.name);
 
@@ -311,10 +311,14 @@ private:
             int i;
             if(index >= 0) i = index;
             else           i = name.index;
-            if(i < vec.size()) return vec[i];
-            else return *static_cast<R*>(nullptr);
+            if(i < vec.size()) 
+            {
+                T retval = vec[i];
+                return retval;
+            }
+            else return *static_cast<typename std::remove_reference<R>::type *>(nullptr);
         }
-        return *static_cast<R*>(nullptr);
+        return *static_cast<typename std::remove_reference<R>::type *>(nullptr);
     }
 
     template<typename T> inline void vectorFill(TH1 * const h, const VarName& name, const T& obj, const double weight)

--- a/Tools/RegisterFunctions.cc
+++ b/Tools/RegisterFunctions.cc
@@ -65,6 +65,9 @@ RegisterFunctionsNTuple::RegisterFunctionsNTuple(bool doSystematics, std::string
     getSearchBin                                = new plotterFunctions::GetSearchBin("_jetpt30");
     getSearchBin_jesTotalUp                     = new plotterFunctions::GetSearchBin("_jetpt30_jesTotalUp");
     getSearchBin_jesTotalDown                   = new plotterFunctions::GetSearchBin("_jetpt30_jesTotalDown");
+    getSearchBin_drPhotonCleaned                = new plotterFunctions::GetSearchBin("_drPhotonCleaned_jetpt30");
+    getSearchBin_drPhotonCleaned_jesTotalUp     = new plotterFunctions::GetSearchBin("_drPhotonCleaned_jetpt30_jesTotalUp");
+    getSearchBin_drPhotonCleaned_jesTotalDown   = new plotterFunctions::GetSearchBin("_drPhotonCleaned_jetpt30_jesTotalDown");
     prepareMiniTupleVars                        = new plotterFunctions::PrepareMiniTupleVars(true);
     systematicPrep                              = new plotterFunctions::SystematicPrep;
     systematicCalc                              = new plotterFunctions::SystematicCalc(sbEra);
@@ -102,23 +105,26 @@ RegisterFunctionsNTuple::~RegisterFunctionsNTuple()
     if(blv_drPhotonCleaned_jetpt30)                 delete blv_drPhotonCleaned_jetpt30;
     if(blv_drPhotonCleaned_jetpt30_jesTotalUp)      delete blv_drPhotonCleaned_jetpt30_jesTotalUp;
     if(blv_drPhotonCleaned_jetpt30_jesTotalDown)    delete blv_drPhotonCleaned_jetpt30_jesTotalDown;
-    if(weights)                      delete weights;
-    if(generatePhotonEfficiency)     delete generatePhotonEfficiency;
-    if(njWeight)                     delete njWeight;
-    if(lepInfo)                      delete lepInfo;
-    if(basicLepton)                  delete basicLepton;
-    if(getSearchBin)                 delete getSearchBin;
-    if(getSearchBin_jesTotalUp)      delete getSearchBin_jesTotalUp;
-    if(getSearchBin_jesTotalDown)    delete getSearchBin_jesTotalDown;
-    if(prepareMiniTupleVars)         delete prepareMiniTupleVars;
-    if(myPDFUnc)                     delete myPDFUnc;
-    if(systematicPrep)               delete systematicPrep;
-    if(systematicCalc)               delete systematicCalc;
-    if(bTagCorrector)                delete bTagCorrector;
-    if(ISRcorrector)                 delete ISRcorrector;
-    if(pileup)                       delete pileup;
-    if(gamma)                        delete gamma;
-    if(shapeNJets)                   delete shapeNJets;
+    if(weights)                                     delete weights;
+    if(generatePhotonEfficiency)                    delete generatePhotonEfficiency;
+    if(njWeight)                                    delete njWeight;
+    if(lepInfo)                                     delete lepInfo;
+    if(basicLepton)                                 delete basicLepton;
+    if(getSearchBin)                                delete getSearchBin;
+    if(getSearchBin_jesTotalUp)                     delete getSearchBin_jesTotalUp;
+    if(getSearchBin_jesTotalDown)                   delete getSearchBin_jesTotalDown;
+    if(getSearchBin_drPhotonCleaned)                delete getSearchBin_drPhotonCleaned;
+    if(getSearchBin_drPhotonCleaned_jesTotalUp)     delete getSearchBin_drPhotonCleaned_jesTotalUp;
+    if(getSearchBin_drPhotonCleaned_jesTotalDown)   delete getSearchBin_drPhotonCleaned_jesTotalDown;
+    if(prepareMiniTupleVars)                        delete prepareMiniTupleVars;
+    if(myPDFUnc)                                    delete myPDFUnc;
+    if(systematicPrep)                              delete systematicPrep;
+    if(systematicCalc)                              delete systematicCalc;
+    if(bTagCorrector)                               delete bTagCorrector;
+    if(ISRcorrector)                                delete ISRcorrector;
+    if(pileup)                                      delete pileup;
+    if(gamma)                                       delete gamma;
+    if(shapeNJets)                                  delete shapeNJets;
 }
         
 void RegisterFunctionsNTuple::registerFunctions(NTupleReader& tr)
@@ -140,7 +146,9 @@ void RegisterFunctionsNTuple::registerFunctions(NTupleReader& tr)
     tr.registerFunction(*blv_drLeptonCleaned_jetpt30);
     tr.registerFunction(*blv_drPhotonCleaned_jetpt30);
     tr.registerFunction(*shapeNJets);
+    // run getSearchBin for both Z nu nu MC (search region) and photon Data and MC (control region)
     tr.registerFunction(*getSearchBin);
+    tr.registerFunction(*getSearchBin_drPhotonCleaned);
     
     // TODO: create JES histograms in MakePlots.C
     // apply JEC to MC only
@@ -161,6 +169,8 @@ void RegisterFunctionsNTuple::registerFunctions(NTupleReader& tr)
         tr.registerFunction(*blv_drPhotonCleaned_jetpt30_jesTotalDown);
         tr.registerFunction(*getSearchBin_jesTotalUp);
         tr.registerFunction(*getSearchBin_jesTotalDown);
+        tr.registerFunction(*getSearchBin_drPhotonCleaned_jesTotalUp);
+        tr.registerFunction(*getSearchBin_drPhotonCleaned_jesTotalDown);
     }
     
 }

--- a/Tools/RegisterFunctions.cc
+++ b/Tools/RegisterFunctions.cc
@@ -144,8 +144,8 @@ void RegisterFunctionsNTuple::registerFunctions(NTupleReader& tr)
     
     // TODO: create JES histograms in MakePlots.C
     // apply JEC to MC only
-    //if (doSystematics_ && tr.checkBranch("GenJet_pt"))
-    if (false)
+    //if (false)
+    if (doSystematics_ && tr.checkBranch("GenJet_pt"))
     {
         tr.registerFunction(*runTopTagger_jesTotalUp);
         tr.registerFunction(*runTopTagger_jesTotalDown);

--- a/Tools/RegisterFunctions.h
+++ b/Tools/RegisterFunctions.h
@@ -90,6 +90,9 @@ private:
     plotterFunctions::GetSearchBin              *getSearchBin;
     plotterFunctions::GetSearchBin              *getSearchBin_jesTotalUp;
     plotterFunctions::GetSearchBin              *getSearchBin_jesTotalDown;
+    plotterFunctions::GetSearchBin              *getSearchBin_drPhotonCleaned;
+    plotterFunctions::GetSearchBin              *getSearchBin_drPhotonCleaned_jesTotalUp;
+    plotterFunctions::GetSearchBin              *getSearchBin_drPhotonCleaned_jesTotalDown;
     plotterFunctions::PrepareMiniTupleVars      *prepareMiniTupleVars;
     plotterFunctions::SystematicPrep            *systematicPrep;
     plotterFunctions::SystematicCalc            *systematicCalc;

--- a/Tools/include/GetSearchBin.h
+++ b/Tools/include/GetSearchBin.h
@@ -1,6 +1,7 @@
 #ifndef GETSEARCHBIN_H
 #define GETSEARCHBIN_H
 
+//#include "units.h"
 #include "TypeDefinitions.h"
 #include "PhotonTools.h"
 #include "SusyAnaTools/Tools/NTupleReader.h"
@@ -91,7 +92,7 @@ namespace plotterFunctions
             int nValidationBinHighDM       = SBv3_highdm_validation(mtb, nJets, nMergedTops, nWs, nResolvedTops, nBottoms, met); 
 
             //----------------------------------------//
-            //--- Updated Unit Bins (October 2019) ---//
+            //--- Updated Unit Bins (December 2019) ---//
             //----------------------------------------//
             int nSBLowDM      = -1;    
             int nSBHighDM     = -1; 
@@ -99,25 +100,53 @@ namespace plotterFunctions
             int nCRUnitHighDM = -1; 
             int nSRUnitLowDM  = -1; 
             int nSRUnitHighDM = -1; 
-            // TODO: This function is very slow! Speed this up.
+            
             // To save time, only run functions if passing baseline (and ISR pt cut for low dm)
-            if (doUnits)
-            {
-                if (SAT_Pass_lowDM && ISRJetPt >= 300)
-                {
-                    //int getUnitNumLowDM(const std::string& key, int njets, int nb, int nsv, float ISRpt, float ptb, float met)
-                    nSBLowDM      = getUnitNumLowDM(  "/binNum",            nJets, nBottoms, nSoftBottoms, ISRJetPt, ptb, met);
-                    nCRUnitLowDM  = getUnitNumLowDM(  "/unitCRNum/phocr",   nJets, nBottoms, nSoftBottoms, ISRJetPt, ptb, met);
-                    nSRUnitLowDM  = getUnitNumLowDM(  "/unitSRNum",         nJets, nBottoms, nSoftBottoms, ISRJetPt, ptb, met);
-                }
-                else if (SAT_Pass_highDM)
-                {
-                    //int getUnitNumHighDM(const std::string& key, float mtb, int njets, int nb, int ntop, int nw, int nres, float ht, float met)
-                    nSBHighDM     = getUnitNumHighDM( "/binNum",            mtb, nJets, nBottoms, nMergedTops, nWs, nResolvedTops, ht, met);
-                    nCRUnitHighDM = getUnitNumHighDM( "/unitCRNum/phocr",   mtb, nJets, nBottoms, nMergedTops, nWs, nResolvedTops, ht, met);
-                    nSRUnitHighDM = getUnitNumHighDM( "/unitSRNum",         mtb, nJets, nBottoms, nMergedTops, nWs, nResolvedTops, ht, met);
-                }
-            }
+            
+            // TODO: This function is very slow! Speed this up.
+            // -------------------- Slow version from Caleb
+            //if (doUnits)
+            //{
+            //    if (SAT_Pass_lowDM && ISRJetPt >= 300)
+            //    {
+            //        //int getUnitNumLowDM(const std::string& key, int njets, int nb, int nsv, float ISRpt, float ptb, float met)
+            //        nSBLowDM      = getUnitNumLowDM(  "/binNum",            nJets, nBottoms, nSoftBottoms, ISRJetPt, ptb, met);
+            //        nCRUnitLowDM  = getUnitNumLowDM(  "/unitCRNum/phocr",   nJets, nBottoms, nSoftBottoms, ISRJetPt, ptb, met);
+            //        nSRUnitLowDM  = getUnitNumLowDM(  "/unitSRNum",         nJets, nBottoms, nSoftBottoms, ISRJetPt, ptb, met);
+            //    }
+            //    else if (SAT_Pass_highDM)
+            //    {
+            //        //int getUnitNumHighDM(const std::string& key, float mtb, int njets, int nb, int ntop, int nw, int nres, float ht, float met)
+            //        nSBHighDM     = getUnitNumHighDM( "/binNum",            mtb, nJets, nBottoms, nMergedTops, nWs, nResolvedTops, ht, met);
+            //        nCRUnitHighDM = getUnitNumHighDM( "/unitCRNum/phocr",   mtb, nJets, nBottoms, nMergedTops, nWs, nResolvedTops, ht, met);
+            //        nSRUnitHighDM = getUnitNumHighDM( "/unitSRNum",         mtb, nJets, nBottoms, nMergedTops, nWs, nResolvedTops, ht, met);
+            //    }
+            //}
+            
+            // ---------------------------- Fast version from Jon
+            // syntax
+            //int SRbin(Pass_Baseline, Pass_QCDCR, Pass_LepCR, Pass_PhoCR, HighDM, LowDM, nb, mtb, ptb, MET, nSoftB, njets, ISRpt, HT, nres, ntop, nw);
+            //int SRunit(Pass_Baseline, Pass_QCDCR, Pass_LepCR, Pass_PhoCR, HighDM, LowDM, nb, mtb, ptb, MET, nSoftB, njets, ISRpt, HT, nres, ntop, nw);
+            //int QCDCRunit(Pass_Baseline, Pass_QCDCR, Pass_LepCR, Pass_PhoCR, HighDM, LowDM, nb, mtb, ptb, MET, nSoftB, njets, ISRpt, HT, nres, ntop, nw);
+            //int lepCRunit(Pass_Baseline, Pass_QCDCR, Pass_LepCR, Pass_PhoCR, HighDM, LowDM, nb, mtb, ptb, MET, nSoftB, njets, ISRpt, HT, nres, ntop, nw);
+            //int phoCRunit(Pass_Baseline, Pass_QCDCR, Pass_LepCR, Pass_PhoCR, HighDM, LowDM, nb, mtb, ptb, MET, nSoftB, njets, ISRpt, HT, nres, ntop, nw);
+            //if (doUnits)
+            //{
+            //    if (SAT_Pass_lowDM && ISRJetPt >= 300)
+            //    {
+            //        //int getUnitNumLowDM(const std::string& key, int njets, int nb, int nsv, float ISRpt, float ptb, float met)
+            //        nSBLowDM      = SRbin(      Pass_Baseline, Pass_QCDCR, Pass_LepCR, Pass_PhoCR, SAT_Pass_highDM, SAT_Pass_lowDM, nBottoms, mtb, ptb, MET, nSoftBottoms, nJets, ISRJetPt, HT, nResolvedTops, nMergedTops, nWs);
+            //        nCRUnitLowDM  = phoCRunit(  Pass_Baseline, Pass_QCDCR, Pass_LepCR, Pass_PhoCR, SAT_Pass_highDM, SAT_Pass_lowDM, nBottoms, mtb, ptb, MET, nSoftBottoms, nJets, ISRJetPt, HT, nResolvedTops, nMergedTops, nWs);
+            //        nSRUnitLowDM  = SRunit(     Pass_Baseline, Pass_QCDCR, Pass_LepCR, Pass_PhoCR, SAT_Pass_highDM, SAT_Pass_lowDM, nBottoms, mtb, ptb, MET, nSoftBottoms, nJets, ISRJetPt, HT, nResolvedTops, nMergedTops, nWs);
+            //    }
+            //    else if (SAT_Pass_highDM)
+            //    {
+            //        //int getUnitNumHighDM(const std::string& key, float mtb, int njets, int nb, int ntop, int nw, int nres, float ht, float met)
+            //        nSBHighDM     = ;
+            //        nCRUnitHighDM = ;
+            //        nSRUnitHighDM = ;
+            //    }
+            //}
 
             
             // compare search bins (hui) vs. search bin units (matt) 

--- a/Tools/include/GetSearchBin.h
+++ b/Tools/include/GetSearchBin.h
@@ -150,36 +150,41 @@ namespace plotterFunctions
                 }
             }
 
+            // check selection in search region
+            if (suffix_.compare("_jetpt30") == 0)
+            {
             
-            // compare search bins (hui) vs. search bin units (matt) 
-            //if (SAT_Pass_lowDM)
-            //{
-            //    if (! (nSearchBinLowDM < 0 && nSBLowDM < 0))
-            //    {
-            //        printf("LowDM; %s; nSB_hui = %d; nSB_matt = %d, nCRUnit = %d, nSRUnit = %d", suffix_.c_str(), nSearchBinLowDM, nSBLowDM, nCRUnitLowDM, nSRUnitLowDM);
-            //        if(nSearchBinLowDM != nSBLowDM) printf(" --- nSB are different --- ");
-            //        printf("\n");
-            //    }
-            //}
-            //if (SAT_Pass_highDM)
-            //{
-            //    if (! (nSearchBinHighDM < 0 && nSBHighDM < 0))
-            //    {
-            //        printf("HighDM; %s; nSB_hui = %d; nSB_matt = %d, nCRUnit = %d, nSRUnit = %d", suffix_.c_str(), nSearchBinHighDM, nSBHighDM, nCRUnitHighDM, nSRUnitHighDM);
-            //        if(nSearchBinHighDM != nSBHighDM) printf(" --- nSB are different --- ");
-            //        printf("\n");
-            //    }
-            //}
-            
-            // print if search bin numbers calculated using different methods are not equal
-            //if (SAT_Pass_lowDM && (nSearchBinLowDM != nSBLowDM))
-            //{
-            //    printf("LowDM; %s; nSB_hui = %d; nSB_matt = %d --- nSB are different --- \n", suffix_.c_str(), nSearchBinLowDM, nSBLowDM);
-            //}
-            //if (SAT_Pass_highDM && (nSearchBinHighDM != nSBHighDM))
-            //{
-            //    printf("HighDM; %s; nSB_hui = %d; nSB_matt = %d --- nSB are different --- \n", suffix_.c_str(), nSearchBinHighDM, nSBHighDM);
-            //}
+                // compare search bins (hui) vs. search bin units (matt) 
+                //if (SAT_Pass_lowDM)
+                //{
+                //    if (! (nSearchBinLowDM < 0 && nSBLowDM < 0))
+                //    {
+                //        printf("LowDM; %s; nSB_hui = %d; nSB_matt = %d, nCRUnit = %d, nSRUnit = %d", suffix_.c_str(), nSearchBinLowDM, nSBLowDM, nCRUnitLowDM, nSRUnitLowDM);
+                //        if(nSearchBinLowDM != nSBLowDM) printf(" --- nSB are different --- ");
+                //        printf("\n");
+                //    }
+                //}
+                //if (SAT_Pass_highDM)
+                //{
+                //    if (! (nSearchBinHighDM < 0 && nSBHighDM < 0))
+                //    {
+                //        printf("HighDM; %s; nSB_hui = %d; nSB_matt = %d, nCRUnit = %d, nSRUnit = %d", suffix_.c_str(), nSearchBinHighDM, nSBHighDM, nCRUnitHighDM, nSRUnitHighDM);
+                //        if(nSearchBinHighDM != nSBHighDM) printf(" --- nSB are different --- ");
+                //        printf("\n");
+                //    }
+                //}
+                
+                // print if search bin numbers calculated using different methods are not equal
+                if (SAT_Pass_lowDM && (nSearchBinLowDM != nSBLowDM))
+                {
+                    printf("LowDM; %s; nSB_hui = %d; nSB_matt = %d --- nSB are different --- \n", suffix_.c_str(), nSearchBinLowDM, nSBLowDM);
+                }
+                if (SAT_Pass_highDM && (nSearchBinHighDM != nSBHighDM))
+                {
+                    printf("HighDM; %s; nSB_hui = %d; nSB_matt = %d --- nSB are different --- \n", suffix_.c_str(), nSearchBinHighDM, nSBHighDM);
+                }
+
+            }
             
             // search bins
             tr.registerDerivedVar("nSearchBinLowDM"             + suffix_, nSearchBinLowDM);

--- a/Tools/include/GetSearchBin.h
+++ b/Tools/include/GetSearchBin.h
@@ -31,11 +31,11 @@ namespace plotterFunctions
         std::string suffix_;
         std::string met_name_  = "MET_pt";
         std::map<std::string, std::string> prefixMap = {
-            {"/binNum",             "bin_"},
+            {"/binNum",            "bin_"},
             {"/unitCRNum/qcdcr",   "bin_qcdcr_"},
             {"/unitCRNum/lepcr",   "bin_lepcr_"},
             {"/unitCRNum/phocr",   "bin_phocr_"},
-            {"/unitSRNum",          "bin_"},
+            {"/unitSRNum",         "bin_"},
         };
 
         void getSearchBin(NTupleReader& tr)

--- a/Tools/include/GetSearchBin.h
+++ b/Tools/include/GetSearchBin.h
@@ -1,7 +1,7 @@
 #ifndef GETSEARCHBIN_H
 #define GETSEARCHBIN_H
 
-//#include "units.h"
+#include "units.hh"
 #include "TypeDefinitions.h"
 #include "PhotonTools.h"
 #include "SusyAnaTools/Tools/NTupleReader.h"
@@ -41,7 +41,7 @@ namespace plotterFunctions
 
         void getSearchBin(NTupleReader& tr)
         {
-            bool doUnits = false;
+            bool doUnits = true;
             // TODO: calculate photon Data and MC yields in photon CR unit bins
             // TODO: calculate Z nu nu MC yields in SR unit bins
             std::string met_label = "MET_pt";
@@ -60,18 +60,20 @@ namespace plotterFunctions
             
             // For photon CR, we need to use _drPhotonCleaned for all variables and metWithPhoton
             const auto& met                 = tr.getVar<data_t>(met_label);
-            const auto& SAT_Pass_lowDM      = tr.getVar<bool>("SAT_Pass_lowDM"  + suffix_);
-            const auto& SAT_Pass_highDM     = tr.getVar<bool>("SAT_Pass_highDM" + suffix_);
-            const auto& nJets               = tr.getVar<int>("nJets"            + suffix_);
-            const auto& nBottoms            = tr.getVar<int>("nBottoms"         + suffix_);
-            const auto& nSoftBottoms        = tr.getVar<int>("nSoftBottoms"     + suffix_);
-            const auto& nMergedTops         = tr.getVar<int>("nMergedTops"      + suffix_);
-            const auto& nResolvedTops       = tr.getVar<int>("nResolvedTops"    + suffix_);
-            const auto& nWs                 = tr.getVar<int>("nWs"              + suffix_);
-            const auto& ht                  = tr.getVar<data_t>("HT"            + suffix_);
-            const auto& ptb                 = tr.getVar<data_t>("ptb"           + suffix_);
-            const auto& mtb                 = tr.getVar<data_t>("mtb"           + suffix_);
-            const auto& ISRJetPt            = tr.getVar<data_t>("ISRJetPt"      + suffix_);
+            const auto& Pass_PhoCR          = tr.getVar<bool>("passPhotonSelection");
+            const auto& SAT_Pass_Baseline   = tr.getVar<bool>("SAT_Pass_Baseline"       + suffix_);
+            const auto& SAT_Pass_lowDM      = tr.getVar<bool>("SAT_Pass_lowDM"          + suffix_);
+            const auto& SAT_Pass_highDM     = tr.getVar<bool>("SAT_Pass_highDM"         + suffix_);
+            const auto& nJets               = tr.getVar<int>("nJets"                    + suffix_);
+            const auto& nBottoms            = tr.getVar<int>("nBottoms"                 + suffix_);
+            const auto& nSoftBottoms        = tr.getVar<int>("nSoftBottoms"             + suffix_);
+            const auto& nMergedTops         = tr.getVar<int>("nMergedTops"              + suffix_);
+            const auto& nResolvedTops       = tr.getVar<int>("nResolvedTops"            + suffix_);
+            const auto& nWs                 = tr.getVar<int>("nWs"                      + suffix_);
+            const auto& ht                  = tr.getVar<data_t>("HT"                    + suffix_);
+            const auto& ptb                 = tr.getVar<data_t>("ptb"                   + suffix_);
+            const auto& mtb                 = tr.getVar<data_t>("mtb"                   + suffix_);
+            const auto& ISRJetPt            = tr.getVar<data_t>("ISRJetPt"              + suffix_);
             
             //------------------------------------------------//
             //--- Updated Search Bins: SBv4 (October 2019) ---//
@@ -130,23 +132,23 @@ namespace plotterFunctions
             //int QCDCRunit(Pass_Baseline, Pass_QCDCR, Pass_LepCR, Pass_PhoCR, HighDM, LowDM, nb, mtb, ptb, MET, nSoftB, njets, ISRpt, HT, nres, ntop, nw);
             //int lepCRunit(Pass_Baseline, Pass_QCDCR, Pass_LepCR, Pass_PhoCR, HighDM, LowDM, nb, mtb, ptb, MET, nSoftB, njets, ISRpt, HT, nres, ntop, nw);
             //int phoCRunit(Pass_Baseline, Pass_QCDCR, Pass_LepCR, Pass_PhoCR, HighDM, LowDM, nb, mtb, ptb, MET, nSoftB, njets, ISRpt, HT, nres, ntop, nw);
-            //if (doUnits)
-            //{
-            //    if (SAT_Pass_lowDM && ISRJetPt >= 300)
-            //    {
-            //        //int getUnitNumLowDM(const std::string& key, int njets, int nb, int nsv, float ISRpt, float ptb, float met)
-            //        nSBLowDM      = SRbin(      Pass_Baseline, Pass_QCDCR, Pass_LepCR, Pass_PhoCR, SAT_Pass_highDM, SAT_Pass_lowDM, nBottoms, mtb, ptb, MET, nSoftBottoms, nJets, ISRJetPt, HT, nResolvedTops, nMergedTops, nWs);
-            //        nCRUnitLowDM  = phoCRunit(  Pass_Baseline, Pass_QCDCR, Pass_LepCR, Pass_PhoCR, SAT_Pass_highDM, SAT_Pass_lowDM, nBottoms, mtb, ptb, MET, nSoftBottoms, nJets, ISRJetPt, HT, nResolvedTops, nMergedTops, nWs);
-            //        nSRUnitLowDM  = SRunit(     Pass_Baseline, Pass_QCDCR, Pass_LepCR, Pass_PhoCR, SAT_Pass_highDM, SAT_Pass_lowDM, nBottoms, mtb, ptb, MET, nSoftBottoms, nJets, ISRJetPt, HT, nResolvedTops, nMergedTops, nWs);
-            //    }
-            //    else if (SAT_Pass_highDM)
-            //    {
-            //        //int getUnitNumHighDM(const std::string& key, float mtb, int njets, int nb, int ntop, int nw, int nres, float ht, float met)
-            //        nSBHighDM     = ;
-            //        nCRUnitHighDM = ;
-            //        nSRUnitHighDM = ;
-            //    }
-            //}
+            if (doUnits)
+            {
+                const bool Pass_QCDCR = false; 
+                const bool Pass_LepCR = false;
+                if (SAT_Pass_lowDM && ISRJetPt >= 300)
+                {
+                    nSBLowDM      = SRbin(      SAT_Pass_Baseline, Pass_QCDCR, Pass_LepCR, Pass_PhoCR, SAT_Pass_highDM, SAT_Pass_lowDM, nBottoms, mtb, ptb, met, nSoftBottoms, nJets, ISRJetPt, ht, nResolvedTops, nMergedTops, nWs);
+                    nCRUnitLowDM  = phoCRunit(  SAT_Pass_Baseline, Pass_QCDCR, Pass_LepCR, Pass_PhoCR, SAT_Pass_highDM, SAT_Pass_lowDM, nBottoms, mtb, ptb, met, nSoftBottoms, nJets, ISRJetPt, ht, nResolvedTops, nMergedTops, nWs);
+                    nSRUnitLowDM  = SRunit(     SAT_Pass_Baseline, Pass_QCDCR, Pass_LepCR, Pass_PhoCR, SAT_Pass_highDM, SAT_Pass_lowDM, nBottoms, mtb, ptb, met, nSoftBottoms, nJets, ISRJetPt, ht, nResolvedTops, nMergedTops, nWs);
+                }
+                else if (SAT_Pass_highDM)
+                {
+                    nSBHighDM      = SRbin(      SAT_Pass_Baseline, Pass_QCDCR, Pass_LepCR, Pass_PhoCR, SAT_Pass_highDM, SAT_Pass_lowDM, nBottoms, mtb, ptb, met, nSoftBottoms, nJets, ISRJetPt, ht, nResolvedTops, nMergedTops, nWs);
+                    nCRUnitHighDM  = phoCRunit(  SAT_Pass_Baseline, Pass_QCDCR, Pass_LepCR, Pass_PhoCR, SAT_Pass_highDM, SAT_Pass_lowDM, nBottoms, mtb, ptb, met, nSoftBottoms, nJets, ISRJetPt, ht, nResolvedTops, nMergedTops, nWs);
+                    nSRUnitHighDM  = SRunit(     SAT_Pass_Baseline, Pass_QCDCR, Pass_LepCR, Pass_PhoCR, SAT_Pass_highDM, SAT_Pass_lowDM, nBottoms, mtb, ptb, met, nSoftBottoms, nJets, ISRJetPt, ht, nResolvedTops, nMergedTops, nWs);
+                }
+            }
 
             
             // compare search bins (hui) vs. search bin units (matt) 


### PR DESCRIPTION
- Use faster functions for getting unit bins
- Apply IST pt >= 300 when calculating low dm unit bin number
- Turn on compile optimization in Makefile
- Fix warnings/errors so that optimized makePlots does not seg fault (similar to issue https://github.com/susy2015/ZInvisible/issues/225)

Here is the initial warning which was fixed. There were additional related errors which were fixed... we no longer pass these values by reference.
```
     In static member function 'static const double& Plotter::tlvGetValue(const string&, const T&) [with T = TLorentzVector]':
     cc1plus: warning: function may return address of local variable [-Wreturn-local-addr]
     In file included from Plotter.cc:1:0:
     Plotter.h:225:39: note: declared here
                  const auto& retval = v.Pt();
                                            ^
     cc1plus: warning: function may return address of local variable [-Wreturn-local-addr]
     Plotter.h:245:38: note: declared here
                  const auto& retval = v.M();
                                           ^
     cc1plus: warning: function may return address of local variable [-Wreturn-local-addr]
     Plotter.h:245:38: note: declared here
     cc1plus: warning: function may return address of local variable [-Wreturn-local-addr]
     Plotter.h:250:39: note: declared here
                  const auto& retval = v.Mt();
                                            ^
     cc1plus: warning: function may return address of local variable [-Wreturn-local-addr]
     Plotter.h:245:38: note: declared here
                  const auto& retval = v.M();
                                           ^
     cc1plus: warning: function may return address of local variable [-Wreturn-local-addr]
     Plotter.h:250:39: note: declared here
                  const auto& retval = v.Mt();
                                            ^
     cc1plus: warning: function may return address of local variable [-Wreturn-local-addr]
     Plotter.h:250:39: note: declared here
     cc1plus: warning: function may return address of local variable [-Wreturn-local-addr]
     Plotter.h:230:40: note: declared here
                  const auto& retval = v.Eta();
                                             ^
     cc1plus: warning: function may return address of local variable [-Wreturn-local-addr]
     Plotter.h:245:38: note: declared here
                  const auto& retval = v.M();
                                           ^
     cc1plus: warning: function may return address of local variable [-Wreturn-local-addr]
     Plotter.h:240:38: note: declared here
                  const auto& retval = v.E();
                                           ^
     cc1plus: warning: function may return address of local variable [-Wreturn-local-addr]
     Plotter.h:235:40: note: declared here
                  const auto& retval = v.Phi();
                                             ^
```