### PR TITLE
Update QCD Overlap Cut

### DIFF
--- a/Tools/PhotonTools.h
+++ b/Tools/PhotonTools.h
@@ -117,25 +117,17 @@ namespace PhotonFunctions
   bool isGenMatched_Method1(const TLorentzVector& photon, std::vector<TLorentzVector> genPhotons){
     double RecoPt = photon.Pt();
     bool genMatched = false;
-    //std::cout << "genPhotons: " << genPhotons.size() << std::endl;
-    for(int i = 0; i < genPhotons.size(); i++){
-      double deltaR = ROOT::Math::VectorUtil::DeltaR(genPhotons[i],photon);
-      double GenPt = genPhotons[i].Pt();
-      double temp_ratio = GenPt/RecoPt;
-      /*
-      std::cout << "igenPhotons: " << i+1 << std::endl;
-      std::cout << "Reco Photon Pt: " << RecoPt << std::endl;
-      std::cout<< "Gen Photon Pt: " << GenPt<< std::endl;
-      std::cout<< "GenPt/RecoPt: " << temp_ratio << std::endl;
-      std::cout << "deltaR: " << deltaR << std::endl;
-      */
-      if (temp_ratio > 0.5 && temp_ratio < 2.0 && deltaR < 0.1){
+    for(int i = 0; i < genPhotons.size(); i++)
+    {
+      double deltaR     = ROOT::Math::VectorUtil::DeltaR(genPhotons[i],photon);
+      double GenPt      = genPhotons[i].Pt();
+      double temp_ratio = RecoPt/GenPt;
+      if (temp_ratio > 0.5 && temp_ratio < 2.0 && deltaR < 0.1)
+      {
         genMatched = true;
         break;
       }
     }
-    //if (genMatched) std::cout << "pass"<< std::endl << std::endl;
-    //else std::cout << "fake"<< std::endl << std::endl;
     return genMatched;
   }
 

--- a/Tools/include/Gamma.h
+++ b/Tools/include/Gamma.h
@@ -27,7 +27,7 @@ namespace plotterFunctions
 
     private:
         std::string year_;
-        bool verbose = false;
+        bool verbose = true;
         enum ID{Loose, Medium, Tight};
 
     void generateGamma(NTupleReader& tr) {
@@ -274,12 +274,12 @@ namespace plotterFunctions
                     dR_GenPhotonGenParton.push_back(dR);
                     if (dR > 0.4)
                     {
-                        if (verbose) printf("FAIL_QCD_CUT event: DR(gen photon, gen parton) = %f\n", dR);
+                        if (verbose) printf("FAIL_QCD_CUT_DR: DR(gen photon, gen parton) = %f\n", dR);
                         passQCDSelection = false;
                     }
                     else
                     {
-                        if (verbose) printf("PASS_QCD_CUT QCD event: DR(gen photon, gen parton) = %f\n", dR);
+                        if (verbose) printf("PASS_QCD_CUT_DR: DR(gen photon, gen parton) = %f\n", dR);
                     }
                 }
             }
@@ -455,6 +455,18 @@ namespace plotterFunctions
             printf("photonSF_Down = %f ",           photonSF_Down);
             printf("passPhotonSelection = %i ",     passPhotonSelection);
             printf("\n");
+        }
+
+        if (verbose)
+        {
+            if (passQCDSelection)
+            {
+                printf("PASS_QCD_CUT_EVENT\n");
+            }
+            else
+            {
+                printf("FAIL_QCD_CUT_EVENT\n");
+            }
         }
         
         // Register derived variables

--- a/Tools/include/Gamma.h
+++ b/Tools/include/Gamma.h
@@ -227,8 +227,8 @@ namespace plotterFunctions
                 
                 if ( (abs(pdgId) > 0 && abs(pdgId) < 7) || pdgId == 9 || pdgId == 21 )
                 {
-                    //if ((statusFlags & 0x2000) == 0x2000)
-                    if ((statusFlags & 0x1) == 0x1)
+                    //if ((statusFlags & 0x1) == 0x1)
+                    if ((statusFlags & 0x2000) == 0x2000)
                     {
                         if(verbose) printf("Found GenParton: pdgId = %d, status = %d, statusFlags = 0x%x, genPartIdxMother = %d, mother_pdgId = %d\n", pdgId, status, statusFlags, genPartIdxMother, mother_pdgId);
                         GenPartonTLV.push_back(GenPartTLV[i]);
@@ -240,8 +240,8 @@ namespace plotterFunctions
                 // stable: status == 1
                 // statusFlag: bit 0 (0x1): isPrompt, bit 13 (0x2000): isLastCopy
                 
-                //if ( pdgId == 22 && status == 1 && ((statusFlags & 0x2000) == 0x2000) )
-                if ( pdgId == 22 && status == 1 && ((statusFlags & 0x1) == 0x1) )
+                //if ( pdgId == 22 && status == 1 && ((statusFlags & 0x1) == 0x1) )
+                if ( pdgId == 22 && status == 1 && ((statusFlags & 0x2000) == 0x2000) )
                 {
                     if(verbose) printf("Found GenPhoton: pdgId = %d, status = %d, statusFlags = 0x%x, genPartIdxMother = %d, mother_pdgId = %d\n", pdgId, status, statusFlags, genPartIdxMother, mother_pdgId);
                     GenPhotonTLV.push_back(GenPartTLV[i]);
@@ -266,19 +266,21 @@ namespace plotterFunctions
                     }
                 }
                 // calculate dR
+                // QCD overlap cut: veto QCD events which have at least one isolated photon
+                bool photonIsIsolated = true;
                 for (const auto& genParton : GenPartonTLV)
                 {
                     float dR = ROOT::Math::VectorUtil::DeltaR(GenPhotonTLV[i], genParton);
                     dR_GenPhotonGenParton.push_back(dR);
-                    if (dR > 0.4)
+                    if (verbose) printf("DR(gen photon, gen parton) = %f\n", dR);
+                    if (dR < 0.4)
                     {
-                        if (verbose) printf("FAIL_QCD_CUT_DR: DR(gen photon, gen parton) = %f\n", dR);
-                        passQCDSelection = false;
+                        photonIsIsolated = false;
                     }
-                    else
-                    {
-                        if (verbose) printf("PASS_QCD_CUT_DR: DR(gen photon, gen parton) = %f\n", dR);
-                    }
+                }
+                if (photonIsIsolated)
+                {
+                    passQCDSelection = false;
                 }
             }
         }
@@ -459,11 +461,11 @@ namespace plotterFunctions
         {
             if (passQCDSelection)
             {
-                printf("PASS_QCD_CUT_EVENT\n");
+                printf("EVENT_PASS_QCD_CUT\n");
             }
             else
             {
-                printf("FAIL_QCD_CUT_EVENT\n");
+                printf("EVENT_FAIL_QCD_CUT\n");
             }
         }
         

--- a/Tools/include/Gamma.h
+++ b/Tools/include/Gamma.h
@@ -415,7 +415,7 @@ namespace plotterFunctions
                                 // print all gen particles
                                 for (int j = 0; j < GenPartTLV.size(); ++j)
                                 {
-                                    printf("Gen Particle %d: (pt=%.3f, eta=%.3f, phi=%.3f, mass=%.3f), pdgId=%d, status=%d, statusFlags=0x%x\n", j, GenPartTLV[j].Pt(), GenPartTLV[j].Eta(), GenPartTLV[j].Phi(), GenPartTLV[j].M(), GenPart_pdgId[j], GenPart_status[j], GenPart_statusFlags[j]);
+                                    printf("Gen Particle %d: (pt=%.3f, eta=%.3f, phi=%.3f, mass=%.3f), pdgId=%d, status=%d, statusFlags=0x%x, genPartIdxMother=%d\n", j, GenPartTLV[j].Pt(), GenPartTLV[j].Eta(), GenPartTLV[j].Phi(), GenPartTLV[j].M(), GenPart_pdgId[j], GenPart_status[j], GenPart_statusFlags[j], GenPart_genPartIdxMother[j]);
                                 }
                             }
                         }

--- a/Tools/include/Gamma.h
+++ b/Tools/include/Gamma.h
@@ -293,8 +293,8 @@ namespace plotterFunctions
                         printf("DR(gen photon, gen parton) = %f\n", dR);
                     }
                 }
-                // QCD overlap cut: veto QCD events which have at least one isolated photon
                 GenPhotonMinPartonDR.push_back(minDR);
+                // QCD overlap cut: veto QCD events which have at least one isolated photon
                 if (photonIsIsolated)
                 {
                     passQCDSelection = false;

--- a/Tools/include/Gamma.h
+++ b/Tools/include/Gamma.h
@@ -28,7 +28,7 @@ namespace plotterFunctions
     private:
         std::string year_;
         bool verbose  = false;
-        bool verbose2 = true;
+        bool verbose2 = false;
         enum ID{Loose, Medium, Tight};
         enum PhotonType{Reco, Direct, Fragmented, Fake};
         std::map<int, std::string> PhotonMap;

--- a/Tools/include/Gamma.h
+++ b/Tools/include/Gamma.h
@@ -168,6 +168,8 @@ namespace plotterFunctions
         auto& GenPhotonTLVEta               = tr.createDerivedVec<TLorentzVector>("GenPhotonTLVEta"); 
         auto& GenPhotonTLVEtaPt             = tr.createDerivedVec<TLorentzVector>("GenPhotonTLVEtaPt"); 
         auto& GenPhotonTLVEtaPtMatched      = tr.createDerivedVec<TLorentzVector>("GenPhotonTLVEtaPtMatched"); 
+        auto& GenPhotonGenPartIdx           = tr.createDerivedVec<int>("GenPhotonGenPartIdx"); 
+        auto& GenPhotonGenPartIdxMother     = tr.createDerivedVec<int>("GenPhotonGenPartIdxMother"); 
         auto& GenPhotonStatus               = tr.createDerivedVec<int>("GenPhotonStatus"); 
         auto& GenPhotonStatusFlags          = tr.createDerivedVec<int>("GenPhotonStatusFlags"); 
         auto& GenPhotonMinPartonDR          = tr.createDerivedVec<float>("GenPhotonMinPartonDR"); 
@@ -244,6 +246,8 @@ namespace plotterFunctions
                     {
                         if(verbose) printf("Found GenPhoton: pdgId = %d, status = %d, statusFlags = 0x%x, genPartIdxMother = %d, mother_pdgId = %d\n", pdgId, status, statusFlags, genPartIdxMother, mother_pdgId);
                         GenPhotonTLV.push_back(GenPartTLV[i]);
+                        GenPhotonGenPartIdx.push_back(i);
+                        GenPhotonGenPartIdxMother.push_back(genPartIdxMother);
                         GenPhotonStatus.push_back(status);
                         GenPhotonStatusFlags.push_back(statusFlags);
                     }
@@ -299,7 +303,7 @@ namespace plotterFunctions
                 
                 // warning 
                 //if ( GenPhotonStatus[i] == 1 && ((GenPhotonStatusFlags[i] & 0x3040) == 0x3040) )
-                if (true)
+                if (false)
                 {
                     if (minDR > 0.4)
                     {
@@ -396,14 +400,22 @@ namespace plotterFunctions
                                 FakePhotons.push_back(PhotonTLV[i]);
                                 photonType = Fake;
                             }
-                            // print reco and gen photons
                             if (verbose2)
                             {
+                                // print reco and gen photons
+                                printf("------------------------------------------------------------------------------------\n");
                                 printf("event=%d, passQCDSelection=%d\n", event, passQCDSelection);
                                 printf("Reco Photon: (pt=%.3f, eta=%.3f, phi=%.3f, mass=%.3f), photonType=%s\n", PhotonTLV[i].Pt(), PhotonTLV[i].Eta(), PhotonTLV[i].Phi(), PhotonTLV[i].M(), PhotonMap[photonType].c_str());
+                                printf("------------------------------------------------------------------------------------\n");
                                 for(int j = 0; j < GenPhotonTLV.size(); ++j)
                                 {
-                                    printf("Gen Photon: (pt=%.3f, eta=%.3f, phi=%.3f, mass=%.3f), status=%d, statusFlags=0x%x, min_parton_DR=%.3f\n", GenPhotonTLV[j].Pt(), GenPhotonTLV[j].Eta(), GenPhotonTLV[j].Phi(), GenPhotonTLV[j].M(), GenPhotonStatus[j], GenPhotonStatusFlags[j], GenPhotonMinPartonDR[j]);
+                                    printf("Gen Photon %d: (pt=%.3f, eta=%.3f, phi=%.3f, mass=%.3f), status=%d, statusFlags=0x%x, genPartIdx=%d, genPartIdxMother=%d, min_parton_DR=%.3f\n", j, GenPhotonTLV[j].Pt(), GenPhotonTLV[j].Eta(), GenPhotonTLV[j].Phi(), GenPhotonTLV[j].M(), GenPhotonStatus[j], GenPhotonStatusFlags[j], GenPhotonGenPartIdx[j], GenPhotonGenPartIdxMother[j], GenPhotonMinPartonDR[j]);
+                                }
+                                printf("------------------------------------------------------------------------------------\n");
+                                // print all gen particles
+                                for (int j = 0; j < GenPartTLV.size(); ++j)
+                                {
+                                    printf("Gen Particle %d: (pt=%.3f, eta=%.3f, phi=%.3f, mass=%.3f), pdgId=%d, status=%d, statusFlags=0x%x\n", j, GenPartTLV[j].Pt(), GenPartTLV[j].Eta(), GenPartTLV[j].Phi(), GenPartTLV[j].M(), GenPart_pdgId[j], GenPart_status[j], GenPart_statusFlags[j]);
                                 }
                             }
                         }

--- a/Tools/include/Gamma.h
+++ b/Tools/include/Gamma.h
@@ -27,8 +27,8 @@ namespace plotterFunctions
 
     private:
         std::string year_;
-        bool verbose  = true;
-        bool verbose2 = false;
+        bool verbose  = false;
+        bool verbose2 = true;
         enum ID{Loose, Medium, Tight};
         enum PhotonType{Reco, Direct, Fragmented, Fake};
         std::map<int, std::string> PhotonMap;
@@ -222,10 +222,8 @@ namespace plotterFunctions
                 // stable: status == 1
                 // outgoing particles of the hardest subprocess: GenPart_status = 23
                 // statusFlag: bit 0 (0x1): isPrompt, bit 13 (0x2000): isLastCopy
-                
                 if ( (abs(pdgId) > 0 && abs(pdgId) < 7) || pdgId == 9 || pdgId == 21 )
                 {
-                    //if ((statusFlags & 0x1) == 0x1)
                     if ((statusFlags & 0x2000) == 0x2000)
                     {
                         if(verbose) printf("Found GenParton: pdgId = %d, status = %d, statusFlags = 0x%x, genPartIdxMother = %d, mother_pdgId = %d\n", pdgId, status, statusFlags, genPartIdxMother, mother_pdgId);
@@ -237,10 +235,8 @@ namespace plotterFunctions
                 // photons: +22
                 // stable: status == 1
                 // statusFlag: bit 0 (0x1): isPrompt, bit 13 (0x2000): isLastCopy
-                
                 if ( pdgId == 22 )
                 {
-                    //if ( status == 1 && ((statusFlags & 0x1) == 0x1) )
                     if ( status == 1 && ((statusFlags & 0x2000) == 0x2000) )
                     {
                         if(verbose) printf("Found GenPhoton: pdgId = %d, status = %d, statusFlags = 0x%x, genPartIdxMother = %d, mother_pdgId = %d\n", pdgId, status, statusFlags, genPartIdxMother, mother_pdgId);
@@ -296,6 +292,7 @@ namespace plotterFunctions
                 
                 // QCD overlap cut: veto QCD events which have at least one isolated photon
                 // only apply QCD overlap cut using 0x2001 photons
+                // statusFlag: bit 0 (0x1): isPrompt, bit 13 (0x2000): isLastCopy
                 if (photonIsIsolated && (GenPhotonStatusFlags[i] == 0x2001))
                 {
                     passQCDSelection = false;
@@ -308,7 +305,6 @@ namespace plotterFunctions
                     if (minDR > 0.4)
                     {
                         printf("event=%d, passQCDSelection=%d\n", event, passQCDSelection);
-                        //printf("WARNING: min_parton_DR > 0.4 for 0x3040 gen photon; Gen Photon: (pt=%.3f, eta=%.3f, phi=%.3f, mass=%.3f), status=%d, statusFlags=0x%x, min_parton_DR=%.3f\n", GenPhotonTLV[i].Pt(), GenPhotonTLV[i].Eta(), GenPhotonTLV[i].Phi(), GenPhotonTLV[i].M(), GenPhotonStatus[i], GenPhotonStatusFlags[i], GenPhotonMinPartonDR[i]);
                         printf("WARNING: min_parton_DR > 0.4; Gen Photon: (pt=%.3f, eta=%.3f, phi=%.3f, mass=%.3f), status=%d, statusFlags=0x%x, min_parton_DR=%.3f\n", GenPhotonTLV[i].Pt(), GenPhotonTLV[i].Eta(), GenPhotonTLV[i].Phi(), GenPhotonTLV[i].M(), GenPhotonStatus[i], GenPhotonStatusFlags[i], GenPhotonMinPartonDR[i]);
                     }
                 }

--- a/Tools/include/Gamma.h
+++ b/Tools/include/Gamma.h
@@ -221,14 +221,14 @@ namespace plotterFunctions
                 // Particle IDs
                 // quarks: +/- (1 to 6)
                 // gluons: + (9 and 21)
-                // statusFlag: isPrompt; statusFlag & 1 == 1
+                // stable: status == 1
                 // outgoing particles of the hardest subprocess: GenPart_status = 23
-                // isHardProcess: (GenPart_statusFlags & 0x80) == 0x80
+                // statusFlag: bit 0 (0x1): isPrompt, bit 13 (0x2000): isLastCopy
                 
                 if ( (abs(pdgId) > 0 && abs(pdgId) < 7) || pdgId == 9 || pdgId == 21 )
                 {
-                    //if ((statusFlags & 1) == 1)
-                    if ((statusFlags & 0x2000) == 0x2000)
+                    //if ((statusFlags & 0x2000) == 0x2000)
+                    if ((statusFlags & 0x1) == 0x1)
                     {
                         if(verbose) printf("Found GenParton: pdgId = %d, status = %d, statusFlags = 0x%x, genPartIdxMother = %d, mother_pdgId = %d\n", pdgId, status, statusFlags, genPartIdxMother, mother_pdgId);
                         GenPartonTLV.push_back(GenPartTLV[i]);
@@ -238,12 +238,10 @@ namespace plotterFunctions
                 // Particle IDs
                 // photons: +22
                 // stable: status == 1
-                // statusFlag: isPrompt; statusFlag & 1 == 1
+                // statusFlag: bit 0 (0x1): isPrompt, bit 13 (0x2000): isLastCopy
                 
-                //if ( pdgId == 22 )
-                //if ( pdgId == 22 && status == 1 )
-                //if ( pdgId == 22 && status == 1 && ((statusFlags & 1) == 1) )
-                if ( pdgId == 22 && status == 1 && ((statusFlags & 0x2000) == 0x2000) )
+                //if ( pdgId == 22 && status == 1 && ((statusFlags & 0x2000) == 0x2000) )
+                if ( pdgId == 22 && status == 1 && ((statusFlags & 0x1) == 0x1) )
                 {
                     if(verbose) printf("Found GenPhoton: pdgId = %d, status = %d, statusFlags = 0x%x, genPartIdxMother = %d, mother_pdgId = %d\n", pdgId, status, statusFlags, genPartIdxMother, mother_pdgId);
                     GenPhotonTLV.push_back(GenPartTLV[i]);

--- a/Tools/include/Gamma.h
+++ b/Tools/include/Gamma.h
@@ -221,7 +221,7 @@ namespace plotterFunctions
                 // gluons: + (9 and 21)
                 // stable: status == 1
                 // outgoing particles of the hardest subprocess: GenPart_status = 23
-                // statusFlag: bit 0 (0x1): isPrompt, bit 13 (0x2000): isLastCopy
+                // statusFlags: bit 0 (0x1): isPrompt, bit 13 (0x2000): isLastCopy
                 if ( (abs(pdgId) > 0 && abs(pdgId) < 7) || pdgId == 9 || pdgId == 21 )
                 {
                     if ((statusFlags & 0x2000) == 0x2000)
@@ -234,7 +234,7 @@ namespace plotterFunctions
                 // Particle IDs
                 // photons: +22
                 // stable: status == 1
-                // statusFlag: bit 0 (0x1): isPrompt, bit 13 (0x2000): isLastCopy
+                // statusFlags: bit 0 (0x1): isPrompt, bit 13 (0x2000): isLastCopy
                 if ( pdgId == 22 )
                 {
                     if ( status == 1 && ((statusFlags & 0x2000) == 0x2000) )
@@ -292,7 +292,7 @@ namespace plotterFunctions
                 
                 // QCD overlap cut: veto QCD events which have at least one isolated photon
                 // only apply QCD overlap cut using 0x2001 photons
-                // statusFlag: bit 0 (0x1): isPrompt, bit 13 (0x2000): isLastCopy
+                // statusFlags: bit 0 (0x1): isPrompt, bit 13 (0x2000): isLastCopy
                 if (photonIsIsolated && (GenPhotonStatusFlags[i] == 0x2001))
                 {
                     passQCDSelection = false;

--- a/Tools/include/Gamma.h
+++ b/Tools/include/Gamma.h
@@ -161,6 +161,7 @@ namespace plotterFunctions
         auto& GenPhotonTLVEtaPtMatched      = tr.createDerivedVec<TLorentzVector>("GenPhotonTLVEtaPtMatched"); 
         auto& GenPhotonStatus               = tr.createDerivedVec<int>("GenPhotonStatus"); 
         auto& GenPhotonStatusFlags          = tr.createDerivedVec<int>("GenPhotonStatusFlags"); 
+        auto& GenPhotonMinPartonDR          = tr.createDerivedVec<float>("GenPhotonMinPartonDR"); 
         auto& RecoPhotonTLV                 = tr.createDerivedVec<TLorentzVector>("RecoPhotonTLV");
         auto& RecoPhotonTLVEta              = tr.createDerivedVec<TLorentzVector>("RecoPhotonTLVEta");
         auto& RecoPhotonTLVEtaPt            = tr.createDerivedVec<TLorentzVector>("RecoPhotonTLVEtaPt");
@@ -271,19 +272,29 @@ namespace plotterFunctions
                         GenPhotonTLVEtaPtMatched.push_back(GenPhotonTLV[i]);
                     }
                 }
-                // calculate dR
-                // QCD overlap cut: veto QCD events which have at least one isolated photon
+                // calculate dR and min dR
+                // check if photon is isolated
+                float minDR = 999.0;
                 bool photonIsIsolated = true;
                 for (const auto& genParton : GenPartonTLV)
                 {
                     float dR = ROOT::Math::VectorUtil::DeltaR(GenPhotonTLV[i], genParton);
                     dR_GenPhotonGenParton.push_back(dR);
-                    if (verbose) printf("DR(gen photon, gen parton) = %f\n", dR);
+                    if (dR < minDR)
+                    {
+                        minDR = dR;
+                    }
                     if (dR < 0.4)
                     {
                         photonIsIsolated = false;
                     }
+                    if (verbose)
+                    {
+                        printf("DR(gen photon, gen parton) = %f\n", dR);
+                    }
                 }
+                // QCD overlap cut: veto QCD events which have at least one isolated photon
+                GenPhotonMinPartonDR.push_back(minDR);
                 if (photonIsIsolated)
                 {
                     passQCDSelection = false;
@@ -339,7 +350,7 @@ namespace plotterFunctions
                                 printf("Reco Photon: (pt=%.3f, eta=%.3f, phi=%.3f, mass=%.3f)\n", PhotonTLV[i].Pt(), PhotonTLV[i].Eta(), PhotonTLV[i].Phi(), PhotonTLV[i].M());
                                 for(int j = 0; j < GenPhotonTLV.size(); ++j)
                                 {
-                                    printf("Gen Photon: (pt=%.3f, eta=%.3f, phi=%.3f, mass=%.3f), status=%d, statusFlags=0x%x\n", GenPhotonTLV[j].Pt(), GenPhotonTLV[j].Eta(), GenPhotonTLV[j].Phi(), GenPhotonTLV[j].M(), GenPhotonStatus[j], GenPhotonStatusFlags[j]);
+                                    printf("Gen Photon: (pt=%.3f, eta=%.3f, phi=%.3f, mass=%.3f), status=%d, statusFlags=0x%x, min_parton_DR=%.3f\n", GenPhotonTLV[j].Pt(), GenPhotonTLV[j].Eta(), GenPhotonTLV[j].Phi(), GenPhotonTLV[j].M(), GenPhotonStatus[j], GenPhotonStatusFlags[j], GenPhotonMinPartonDR[j]);
                                 }
                             }
                             // get scale factor for MC

--- a/Tools/include/Gamma.h
+++ b/Tools/include/Gamma.h
@@ -159,6 +159,8 @@ namespace plotterFunctions
         auto& GenPhotonTLVEta               = tr.createDerivedVec<TLorentzVector>("GenPhotonTLVEta"); 
         auto& GenPhotonTLVEtaPt             = tr.createDerivedVec<TLorentzVector>("GenPhotonTLVEtaPt"); 
         auto& GenPhotonTLVEtaPtMatched      = tr.createDerivedVec<TLorentzVector>("GenPhotonTLVEtaPtMatched"); 
+        auto& GenPhotonStatus               = tr.createDerivedVec<int>("GenPhotonStatus"); 
+        auto& GenPhotonStatusFlags          = tr.createDerivedVec<int>("GenPhotonStatusFlags"); 
         auto& RecoPhotonTLV                 = tr.createDerivedVec<TLorentzVector>("RecoPhotonTLV");
         auto& RecoPhotonTLVEta              = tr.createDerivedVec<TLorentzVector>("RecoPhotonTLVEta");
         auto& RecoPhotonTLVEtaPt            = tr.createDerivedVec<TLorentzVector>("RecoPhotonTLVEtaPt");
@@ -242,10 +244,13 @@ namespace plotterFunctions
                 // statusFlag: bit 0 (0x1): isPrompt, bit 13 (0x2000): isLastCopy
                 
                 //if ( pdgId == 22 && status == 1 && ((statusFlags & 0x1) == 0x1) )
-                if ( pdgId == 22 && status == 1 && ((statusFlags & 0x2000) == 0x2000) )
+                //if ( pdgId == 22 && status == 1 && ((statusFlags & 0x2000) == 0x2000) )
+                if ( pdgId == 22 )
                 {
                     if(verbose) printf("Found GenPhoton: pdgId = %d, status = %d, statusFlags = 0x%x, genPartIdxMother = %d, mother_pdgId = %d\n", pdgId, status, statusFlags, genPartIdxMother, mother_pdgId);
                     GenPhotonTLV.push_back(GenPartTLV[i]);
+                    GenPhotonStatus.push_back(status);
+                    GenPhotonStatusFlags.push_back(statusFlags);
                 }
             }
             //Apply cuts to Gen Photons
@@ -331,10 +336,10 @@ namespace plotterFunctions
                             // print reco and gen photons
                             if (verbose2)
                             {
-                                printf("Reco Photon: (pt=%.3f, eta=%.3f)\n", PhotonTLV[i].Pt(), PhotonTLV[i].Eta());
-                                for(int i = 0; i < GenPhotonTLV.size(); ++i)
+                                printf("Reco Photon: (pt=%.3f, eta=%.3f, phi=%.3f, mass=%.3f)\n", PhotonTLV[i].Pt(), PhotonTLV[i].Eta(), PhotonTLV[i].Phi(), PhotonTLV[i].M());
+                                for(int j = 0; j < GenPhotonTLV.size(); ++j)
                                 {
-                                    printf("Gen Photon: (pt=%.3f, eta=%.3f)\n", GenPhotonTLV[i].Pt(), GenPhotonTLV[i].Eta());
+                                    printf("Gen Photon: (pt=%.3f, eta=%.3f, phi=%.3f, mass=%.3f), status=%d, statusFlags=0x%x\n", GenPhotonTLV[j].Pt(), GenPhotonTLV[j].Eta(), GenPhotonTLV[j].Phi(), GenPhotonTLV[j].M(), GenPhotonStatus[j], GenPhotonStatusFlags[j]);
                                 }
                             }
                             // get scale factor for MC

--- a/Tools/include/Gamma.h
+++ b/Tools/include/Gamma.h
@@ -241,8 +241,7 @@ namespace plotterFunctions
                 if ( pdgId == 22 )
                 {
                     //if ( status == 1 && ((statusFlags & 0x1) == 0x1) )
-                    //if ( status == 1 && ((statusFlags & 0x2000) == 0x2000) )
-                    if (true)
+                    if ( status == 1 && ((statusFlags & 0x2000) == 0x2000) )
                     {
                         if(verbose) printf("Found GenPhoton: pdgId = %d, status = %d, statusFlags = 0x%x, genPartIdxMother = %d, mother_pdgId = %d\n", pdgId, status, statusFlags, genPartIdxMother, mother_pdgId);
                         GenPhotonTLV.push_back(GenPartTLV[i]);
@@ -296,7 +295,8 @@ namespace plotterFunctions
                 GenPhotonMinPartonDR.push_back(minDR);
                 
                 // QCD overlap cut: veto QCD events which have at least one isolated photon
-                if (photonIsIsolated)
+                // only apply QCD overlap cut using 0x2001 photons
+                if (photonIsIsolated && (GenPhotonStatusFlags[i] == 0x2001))
                 {
                     passQCDSelection = false;
                 }

--- a/Tools/include/Gamma.h
+++ b/Tools/include/Gamma.h
@@ -220,11 +220,11 @@ namespace plotterFunctions
                 // quarks: +/- (1 to 6)
                 // gluons: + (9 and 21)
                 // stable: status == 1
-                // outgoing particles of the hardest subprocess: GenPart_status = 23
+                // outgoing particles of the hardest subprocess: status == 23
                 // statusFlags: bit 0 (0x1): isPrompt, bit 13 (0x2000): isLastCopy
                 if ( (abs(pdgId) > 0 && abs(pdgId) < 7) || pdgId == 9 || pdgId == 21 )
                 {
-                    if ((statusFlags & 0x2000) == 0x2000)
+                    if ((statusFlags & 0x2001) == 0x2001)
                     {
                         if(verbose) printf("Found GenParton: pdgId = %d, status = %d, statusFlags = 0x%x, genPartIdxMother = %d, mother_pdgId = %d\n", pdgId, status, statusFlags, genPartIdxMother, mother_pdgId);
                         GenPartonTLV.push_back(GenPartTLV[i]);

--- a/Tools/include/Gamma.h
+++ b/Tools/include/Gamma.h
@@ -27,8 +27,8 @@ namespace plotterFunctions
 
     private:
         std::string year_;
-        bool verbose  = false;
-        bool verbose2 = true;
+        bool verbose  = true;
+        bool verbose2 = false;
         enum ID{Loose, Medium, Tight};
         enum PhotonType{Reco, Direct, Fragmented, Fake};
         std::map<int, std::string> PhotonMap;

--- a/Tools/include/Gamma.h
+++ b/Tools/include/Gamma.h
@@ -27,7 +27,8 @@ namespace plotterFunctions
 
     private:
         std::string year_;
-        bool verbose = true;
+        bool verbose  = false;
+        bool verbose2 = true;
         enum ID{Loose, Medium, Tight};
 
     void generateGamma(NTupleReader& tr) {
@@ -327,6 +328,15 @@ namespace plotterFunctions
                         // MC Only
                         if (! isData)
                         {
+                            // print reco and gen photons
+                            if (verbose2)
+                            {
+                                printf("Reco Photon: (pt=%.3f, eta=%.3f)\n", PhotonTLV[i].Pt(), PhotonTLV[i].Eta());
+                                for(int i = 0; i < GenPhotonTLV.size(); ++i)
+                                {
+                                    printf("Gen Photon: (pt=%.3f, eta=%.3f)\n", GenPhotonTLV[i].Pt(), GenPhotonTLV[i].Eta());
+                                }
+                            }
                             // get scale factor for MC
                             cutPhotonSF.push_back(Photon_SF[i]);
                             cutPhotonSF_Up.push_back(Photon_SF[i] + Photon_SF_Err[i]);


### PR DESCRIPTION
Update QCD Overlap Cut
- Fix photon isolation DR logic; photon is isolated if DR(photon, parton) > 0.4 for all partons (not just for any parton)
- Use gen photons with status 1 and statusFlags bit 13 (0x2000): isLastCopy for full gen photon collection (used for Fragmenation photon determination)
- Use gen photons with status 1 and statusFlags == 0x2001 for QCD overlap cut
- Use gen partons with statusFlags bit 0 (0x1): isPrompt and bit 13 (0x2000): isLastCopy for both QCD overlap cut and for Fragmentation photon determination

Info on statusFlag:
- bit 0 (0x1): isPrompt
- bit 13 (0x2000): isLastCopy