### PR TITLE
Estimate Systematic Ranges

### DIFF
--- a/Tools/python/compare.py
+++ b/Tools/python/compare.py
@@ -365,59 +365,81 @@ if __name__ == "__main__":
     #
     # -------------------------- #
     
-    # v6p5 ntuple unblinding Run2 comparison
-    # comparison with Matt
-    # Run2
-    values = ["data", "pred"]
-    labels = ["Caleb", "Matt"]
-    h_names = {"data" : "hdata", "znunu_pred" : "hznunu"}
-    f_map = {}
-    #f_map["Caleb"] = "/uscms/home/caleb/archive/zinv_results/2020-05-19/prediction_histos/searchBinsZinv_Run2.root"
-    #f_map["Matt"]  = "/eos/uscms/store/user/lpcsusyhad/Stop_production/LimitInputs/19May2020_Run2Unblind_dev_v6/SearchBinsPlot/SumOfBkg.root"
-    f_map["Caleb"] = "/uscms/home/caleb/archive/zinv_results/2020-07-06/prediction_histos/searchBinsZinv_Run2.root"
-    f_map["Matt"]  = "/uscms/home/mkilpatr/nobackup/CMSSW_9_4_10/src/AnalysisMethods/EstTools/SUSYNano19/getFinalPlot/SumOfBkg.root"
-    search(f_map, values, labels, h_names, "Run2")
+    if False:
+        # v6p5 ntuple unblinding Run2 comparison
+        # comparison with Matt
+        # Run2
+        values = ["data", "pred"]
+        labels = ["Caleb", "Matt"]
+        h_names = {"data" : "hdata", "znunu_pred" : "hznunu"}
+        f_map = {}
+        #f_map["Caleb"] = "/uscms/home/caleb/archive/zinv_results/2020-05-19/prediction_histos/searchBinsZinv_Run2.root"
+        #f_map["Matt"]  = "/eos/uscms/store/user/lpcsusyhad/Stop_production/LimitInputs/19May2020_Run2Unblind_dev_v6/SearchBinsPlot/SumOfBkg.root"
+        f_map["Caleb"] = "/uscms/home/caleb/archive/zinv_results/2020-07-06/prediction_histos/searchBinsZinv_Run2.root"
+        f_map["Matt"]  = "/uscms/home/mkilpatr/nobackup/CMSSW_9_4_10/src/AnalysisMethods/EstTools/SUSYNano19/getFinalPlot/SumOfBkg.root"
+        search(f_map, values, labels, h_names, "Run2")
 
-    # compare systematics with Matt
-    values = ["syst_up", "syst_down"]
-    labels = ["Caleb", "Matt"]
-    h_names = {"syst_up" : "znunu_syst_up", "syst_down" : "znunu_syst_dn"}
-    f_map = {}
-    f_map["Caleb"] = "/uscms/home/caleb/archive/zinv_results/2020-07-06/prediction_histos/searchBinsZinv_totalPredSyst_Run2.root"
-    f_map["Matt"]  = "/uscms/home/mkilpatr/nobackup/CMSSW_9_4_10/src/AnalysisMethods/EstTools/SUSYNano19/getFinalPlot/SumOfBkg.root"
-    search(f_map, values, labels, h_names, "Run2")
+        # compare systematics with Matt
+        values = ["syst_up", "syst_down"]
+        labels = ["Caleb", "Matt"]
+        h_names = {"syst_up" : "znunu_syst_up", "syst_down" : "znunu_syst_dn"}
+        f_map = {}
+        f_map["Caleb"] = "/uscms/home/caleb/archive/zinv_results/2020-07-06/prediction_histos/searchBinsZinv_totalPredSyst_Run2.root"
+        f_map["Matt"]  = "/uscms/home/mkilpatr/nobackup/CMSSW_9_4_10/src/AnalysisMethods/EstTools/SUSYNano19/getFinalPlot/SumOfBkg.root"
+        search(f_map, values, labels, h_names, "Run2")
 
-    # --- Jon's histograms --- #
-    #
-    # data:         Data
-    # QCD pred:     QCD
-    #
-    # -------------------------- #
+        # --- Jon's histograms --- #
+        #
+        # data:         Data
+        # QCD pred:     QCD
+        #
+        # -------------------------- #
+        
+        # comparison with Jon
+        # /uscms_data/d3/jsw/SusyAna/CMSSW_10_2_9/src/notebooks/Yields_v6_5/2016_SearchBins_QCDResidMET.root
+        # /eos/uscms/store/user/lpcsusyhad/Stop_production/LimitInputs/26May2020_2016Unblind_dev_v6/SearchBinsPlot/SearchBins_QCDResidMET.root
+        # 2016
+        values = ["data"]
+        labels = ["Caleb", "Jon"]
+        h_names = {"data" : "Data", "qcd_pred" : "QCD"}
+        f_map = {}
+        f_map["Caleb"] = "/uscms/home/caleb/archive/zinv_results/2020-05-19/prediction_histos/searchBinsZinv_2016.root"
+        f_map["Jon"]   = "/eos/uscms/store/user/lpcsusyhad/Stop_production/LimitInputs/26May2020_2016Unblind_dev_v6/SearchBinsPlot/SearchBins_QCDResidMET.root"
+        search(f_map, values, labels, h_names, "2016")
+
+        
+        # --- Caleb's comparison --- #
+        #
+        # compare using Rz per year with using Run 2 Rz
+        #
+        # -------------------------- #
+        values = ["pred"]
+        labels = ["RzRun2", "RzPerYear"]
+        f_map = {}
+        f_map["RzRun2"]    = "/uscms_data/d3/caleb/SusyAnalysis/CMSSW_10_2_9/src/ZInvisible/Tools/prediction_histos/searchBinsZinv_Run2.root"
+        f_map["RzPerYear"] = "/uscms_data/d3/caleb/SusyAnalysis/CMSSW_10_2_9/src/ZInvisible/Tools/prediction_histos/searchBinsZinv_useRzPerYear_Run2.root"
+        searchCompareMyHists(f_map, values, labels, "Run2")
     
-    # comparison with Jon
-    # /uscms_data/d3/jsw/SusyAna/CMSSW_10_2_9/src/notebooks/Yields_v6_5/2016_SearchBins_QCDResidMET.root
-    # /eos/uscms/store/user/lpcsusyhad/Stop_production/LimitInputs/26May2020_2016Unblind_dev_v6/SearchBinsPlot/SearchBins_QCDResidMET.root
-    # 2016
-    values = ["data"]
-    labels = ["Caleb", "Jon"]
-    h_names = {"data" : "Data", "qcd_pred" : "QCD"}
-    f_map = {}
-    f_map["Caleb"] = "/uscms/home/caleb/archive/zinv_results/2020-05-19/prediction_histos/searchBinsZinv_2016.root"
-    f_map["Jon"]   = "/eos/uscms/store/user/lpcsusyhad/Stop_production/LimitInputs/26May2020_2016Unblind_dev_v6/SearchBinsPlot/SearchBins_QCDResidMET.root"
-    search(f_map, values, labels, h_names, "2016")
-
-    
-    # --- Caleb's comparison --- #
-    #
-    # compare using Rz per year with using Run 2 Rz
-    #
-    # -------------------------- #
-    values = ["pred"]
-    labels = ["RzRun2", "RzPerYear"]
-    f_map = {}
-    f_map["RzRun2"]    = "/uscms_data/d3/caleb/SusyAnalysis/CMSSW_10_2_9/src/ZInvisible/Tools/prediction_histos/searchBinsZinv_Run2.root"
-    f_map["RzPerYear"] = "/uscms_data/d3/caleb/SusyAnalysis/CMSSW_10_2_9/src/ZInvisible/Tools/prediction_histos/searchBinsZinv_useRzPerYear_Run2.root"
-    searchCompareMyHists(f_map, values, labels, "Run2")
+    if True:
+        # --- Caleb's comparison --- #
+        #
+        # compare v6p5 runs (before and after changes to the prediciton)
+        # compare v6p5 vs. v7 predictions
+        #
+        # -------------------------- #
+        values = ["pred"]
+        labels = ["v6p5_May31", "v6p5_July24"]
+        f_map = {}
+        f_map["v6p5_May31"]    = "/uscms/home/caleb/archive/zinv_results/2020-05-31/prediction_histos/searchBinsZinv_Run2.root"
+        f_map["v6p5_July24"]   = "/uscms/home/caleb/archive/zinv_results/2020-07-24/prediction_histos/searchBinsZinv_Run2.root"
+        searchCompareMyHists(f_map, values, labels, "Run2")
+        
+        values = ["pred"]
+        labels = ["v6p5_July24", "v7"]
+        f_map = {}
+        f_map["v6p5_July24"]    = "/uscms/home/caleb/archive/zinv_results/2020-07-24/prediction_histos/searchBinsZinv_Run2.root"
+        f_map["v7"]             = "/uscms/home/caleb/archive/zinv_results/2020-07-31/prediction_histos/searchBinsZinv_Run2.root"
+        searchCompareMyHists(f_map, values, labels, "Run2")
     
 
 

--- a/Tools/python/plot_sgamma.py
+++ b/Tools/python/plot_sgamma.py
@@ -109,9 +109,9 @@ def run(era):
     labels = ["sgamma_searchbins", "sgamma_crunits"]
     
     # --- plot --- #
-    # plot(histograms, labels, name, title, x_title, x_min, x_max, y_min, y_max, era, plot_dir, showStats=False, normalize=False, setLog=False)
-    plot(histograms_1, labels, "sgamma_binning1", "Sgamma for " + era, "Sgamma", limits_1[0], limits_1[1], 0.0, 200.0, era, "more_plots", showStats=True) 
-    plot(histograms_2, labels, "sgamma_binning2", "Sgamma for " + era, "Sgamma", limits_2[0], limits_2[1], 0.0, 60.0,  era, "more_plots", showStats=True) 
+    # plot(histograms, labels, name, title, x_title, y_title, x_min, x_max, y_min, y_max, era, plot_dir, showStats=False, normalize=False, setLog=False)
+    plot(histograms_1, labels, "sgamma_binning1", "Sgamma for " + era, "Sgamma", "Events", limits_1[0], limits_1[1], 0.0, 200.0, era, "more_plots", showStats=True) 
+    plot(histograms_2, labels, "sgamma_binning2", "Sgamma for " + era, "Sgamma", "Events", limits_2[0], limits_2[1], 0.0, 60.0,  era, "more_plots", showStats=True) 
    
     if verbose > 0:
         print "Total data  = {0}".format(total_phocr_data)

--- a/Tools/python/plot_sgamma.py
+++ b/Tools/python/plot_sgamma.py
@@ -109,9 +109,9 @@ def run(era):
     labels = ["sgamma_searchbins", "sgamma_crunits"]
     
     # --- plot --- #
-    # plot(histograms, labels, name, title, x_title, x_min, x_max, y_min, y_max, era, showStats=False, normalize=False, setLog=False)
-    plot(histograms_1, labels, "sgamma_binning1", "Sgamma for " + era, "Sgamma", limits_1[0], limits_1[1], 0.0, 200.0, era, showStats=True) 
-    plot(histograms_2, labels, "sgamma_binning2", "Sgamma for " + era, "Sgamma", limits_2[0], limits_2[1], 0.0, 60.0,  era, showStats=True) 
+    # plot(histograms, labels, name, title, x_title, x_min, x_max, y_min, y_max, era, plot_dir, showStats=False, normalize=False, setLog=False)
+    plot(histograms_1, labels, "sgamma_binning1", "Sgamma for " + era, "Sgamma", limits_1[0], limits_1[1], 0.0, 200.0, era, "more_plots", showStats=True) 
+    plot(histograms_2, labels, "sgamma_binning2", "Sgamma for " + era, "Sgamma", limits_2[0], limits_2[1], 0.0, 60.0,  era, "more_plots", showStats=True) 
    
     if verbose > 0:
         print "Total data  = {0}".format(total_phocr_data)

--- a/Tools/python/quick_plot.py
+++ b/Tools/python/quick_plot.py
@@ -48,9 +48,9 @@ def plotMergedTopPartons(era, result_file, verbose):
     
     # WARNING: if using setLog=True, do not use y_min = 0
     # WARNING: currently stats do not show properly on log scale... this would need work to fix
-    # plot(histograms, labels, name, title, x_title, x_min, x_max, y_min, y_max, era, showStats=False, normalize=False, setLog=False)
-    plot(histograms, labels, name_1, title_1, x_title, x_min, x_max, y_min_1, y_max_1, era, showStats=False, normalize=False, setLog=True)
-    plot(histograms, labels, name_2, title_2, x_title, x_min, x_max, y_min_2, y_max_2, era, showStats=True, normalize=True)
+    # plot(histograms, labels, name, title, x_title, x_min, x_max, y_min, y_max, era, plot_dir, showStats=False, normalize=False, setLog=False)
+    plot(histograms, labels, name_1, title_1, x_title, x_min, x_max, y_min_1, y_max_1, era, "more_plots", showStats=False, normalize=False, setLog=True)
+    plot(histograms, labels, name_2, title_2, x_title, x_min, x_max, y_min_2, y_max_2, era, "more_plots", showStats=True, normalize=True)
 
 # plot Nb, Nsv, Nj for different eras
 def plotVars(var, particle, eras, runMap, varMap, verbose):

--- a/Tools/python/quick_plot.py
+++ b/Tools/python/quick_plot.py
@@ -33,6 +33,7 @@ def plotMergedTopPartons(era, result_file, verbose):
     title_1 = "MergedTop_nGenPart, nmt=1, {0}".format(era)
     title_2 = "MergedTop_nGenPart, nmt=1, {0}, norm.".format(era)
     x_title = "MergedTop_nGenPart"
+    y_title = "Events"
     x_min   = 0
     x_max   = 11
     # y limits for TTbar, ZNuNu, GJets
@@ -48,9 +49,9 @@ def plotMergedTopPartons(era, result_file, verbose):
     
     # WARNING: if using setLog=True, do not use y_min = 0
     # WARNING: currently stats do not show properly on log scale... this would need work to fix
-    # plot(histograms, labels, name, title, x_title, x_min, x_max, y_min, y_max, era, plot_dir, showStats=False, normalize=False, setLog=False)
-    plot(histograms, labels, name_1, title_1, x_title, x_min, x_max, y_min_1, y_max_1, era, "more_plots", showStats=False, normalize=False, setLog=True)
-    plot(histograms, labels, name_2, title_2, x_title, x_min, x_max, y_min_2, y_max_2, era, "more_plots", showStats=True, normalize=True)
+    # plot(histograms, labels, name, title, x_title, y_title, x_min, x_max, y_min, y_max, era, plot_dir, showStats=False, normalize=False, setLog=False)
+    plot(histograms, labels, name_1, title_1, x_title, y_title, x_min, x_max, y_min_1, y_max_1, era, "more_plots", showStats=False, normalize=False, setLog=True)
+    plot(histograms, labels, name_2, title_2, x_title, y_title, x_min, x_max, y_min_2, y_max_2, era, "more_plots", showStats=True, normalize=True)
 
 # plot Nb, Nsv, Nj for different eras
 def plotVars(var, particle, eras, runMap, varMap, verbose):

--- a/Tools/python/run_systematics.py
+++ b/Tools/python/run_systematics.py
@@ -10,6 +10,7 @@ from norm_lepton_zmass import Normalization
 from shape_photon_met import Shape
 from search_bins import  ValidationBins, ValidationBinsMETStudy, SearchBins, CRUnitBins
 from tools import invert, setupHist, stringifyMap, removeCuts, ERROR_SYST, isclose
+from tools import plot as tplot
 
 # set numpy to provide warnings instead of just printing errors
 np.seterr(all='warn')
@@ -778,9 +779,9 @@ def getTotalSystematicsPrediction(SearchBinObject, CRBinObject, N, S, runMap, sy
                 print "LargeSyst: {0}, {1}, bin {2}, syst_up = {3}".format(era, syst, i, values_up[i])
             if values_down[i] >= maxVal: 
                 print "LargeSyst: {0}, {1}, bin {2}, syst_down = {3}".format(era, syst, i, values_down[i])
-        
+
         # --- plot 1D histograms
-        c = ROOT.TCanvas("c", "c", 800, 800)
+        #c = ROOT.TCanvas("c", "c", 800, 800)
         
         h_up    = ROOT.TH1F("h_up",   "h_up",   100, 1.0, 3.0)
         h_down  = ROOT.TH1F("h_down", "h_down", 100, 1.0, 3.0)
@@ -792,25 +793,35 @@ def getTotalSystematicsPrediction(SearchBinObject, CRBinObject, N, S, runMap, sy
         name = "{0}_systDistribution_{1}".format("search", syst)
         title = "Z to Invisible: syst. distribution " + name + " for " + era
         x_title = "systematic"
-        setupHist(h_up,     title, x_title, "number of search bins",  color_red,    0.0, 200.0)
-        setupHist(h_down,   title, x_title, "number of search bins",  color_blue,   0.0, 200.0)
+
+        # setupHist(h_up,     title, x_title, "number of search bins",  color_red,    0.0, 200.0)
+        # setupHist(h_down,   title, x_title, "number of search bins",  color_blue,   0.0, 200.0)
+        # 
+        # h_up.Draw(draw_option)
+        # h_down.Draw(draw_option + " same")
+        # 
+        # # legend: TLegend(x1,y1,x2,y2)
+        # legend = ROOT.TLegend(legend_x1, legend_y1, legend_x2, legend_y2)
+        # legend.AddEntry(h_up,           "syst up",                  "l")
+        # legend.AddEntry(h_down,         "syst down",                "l")
+        # legend.Draw()
+        # 
+        # # save histograms
+        # plot_name = out_dir + name + eraTag
+        # c.Update()
+        # c.SaveAs(plot_name + ".png")
         
-        h_up.Draw(draw_option)
-        h_down.Draw(draw_option + " same")
+        # --- plot 1D histograms using tools.plot()
+        histograms = [h_up, h_down]
+        labels = ["syst_up", "syst_down"]
+        # tools.plot(histograms, labels, name, title, x_title, x_min, x_max, y_min, y_max, era, plot_dir, showStats=False, normalize=False, setLog=False)
+        tplot(histograms, labels, name, title, x_title, 1.0, 3.0, 0.0, 200.0, era, out_dir, showStats=True)
         
-        # legend: TLegend(x1,y1,x2,y2)
-        legend = ROOT.TLegend(legend_x1, legend_y1, legend_x2, legend_y2)
-        legend.AddEntry(h_up,           "syst up",                  "l")
-        legend.AddEntry(h_down,         "syst down",                "l")
-        legend.Draw()
-        
-        # save histograms
-        plot_name = out_dir + name + eraTag
-        c.Update()
-        c.SaveAs(plot_name + ".png")
-        del c
+        # del c
+        del histograms
         del h_up
         del h_down
+        
 
     # sort by median, greatest to least
     medianArray = np.array(medianList, dtype=[('x', 'S30'), ('y', float)])

--- a/Tools/python/run_systematics.py
+++ b/Tools/python/run_systematics.py
@@ -918,7 +918,7 @@ def getTotalSystematicsPrediction(SearchBinObject, CRBinObject, N, S, runMap, sy
         del h_down
         
 
-    # estimate ranges
+    # --- estimate ranges
     infoFile.write("--- estimated systematic ranges ---\n")
     for syst in systValMap:
         # Find the mean and standard deviation of the resulting set of numbers.
@@ -928,9 +928,12 @@ def getTotalSystematicsPrediction(SearchBinObject, CRBinObject, N, S, runMap, sy
         val_std  = np.std(values)
         low  = 100.0 * np.exp(val_mean - val_std)
         high = 100.0 * np.exp(val_mean + val_std)
-        infoFile.write("{0:>30}  {1:.2f}% -- {2:.2f}%\n".format(syst, low, high))
+        # decimal
+        #infoFile.write("{0:>30}  {1:.2f}% -- {2:.2f}%\n".format(syst, low, high))
+        # integer
+        infoFile.write("{0:>30}  {1:.0f}% -- {2:.0f}%\n".format(syst, low, high))
     
-    # sort by median, greatest to least
+    # --- sort by median, greatest to least
     medianArray = np.array(medianList, dtype=[('x', 'S30'), ('y', float)])
     medianArray[::-1].sort(order='y')
 

--- a/Tools/python/run_systematics.py
+++ b/Tools/python/run_systematics.py
@@ -534,7 +534,7 @@ def getTotalSystematicsPrediction(SearchBinObject, CRBinObject, N, S, runMap, sy
             
             p  = p1
 
-            print "PREDICTION search bin {0}: {1}, {2}, {3}".format(b, p1, p2, isclose(p1, p2, rel_tol=1e-06))
+            #print "PREDICTION search bin {0}: {1}, {2}, {3}".format(b, p1, p2, isclose(p1, p2, rel_tol=1e-06))
             
             log_syst_up_sum    = 0.0
             log_syst_down_sum  = 0.0
@@ -754,13 +754,15 @@ def getTotalSystematicsPrediction(SearchBinObject, CRBinObject, N, S, runMap, sy
         # get percentages >= 0.0%
         ave_up   = 100 * (np.average(values_up) - 1)
         ave_down = 100 * (np.average(values_down) - 1)
+        med_up   = 100 * (np.median(values_up) - 1)
+        med_down = 100 * (np.median(values_down) - 1)
         min_up   = 100 * (min(values_up) - 1)
         min_down = 100 * (min(values_down) - 1)
         max_up   = 100 * (max(values_up) - 1)
         max_down = 100 * (max(values_down) - 1)
         # record average systematic here
-        infoFile.write("{0}  {1}_Up    ave={2:.3f}%, range=[{3:.3f}%, {4:.3f}%]\n".format("total", syst, ave_up,   min_up,   max_up   ))
-        infoFile.write("{0}  {1}_Down  ave={2:.3f}%, range=[{3:.3f}%, {4:.3f}%]\n".format("total", syst, ave_down, min_down, max_down ))
+        infoFile.write("{0}  {1}_Up    ave={2:.3f}%, med={3:.3f}%, range=[{4:.3f}%, {5:.3f}%]\n".format("total", syst, ave_up,   med_up,   min_up,   max_up   ))
+        infoFile.write("{0}  {1}_Down  ave={2:.3f}%, med={3:.3f}%, range=[{4:.3f}%, {5:.3f}%]\n".format("total", syst, ave_down, med_down, min_down, max_down ))
 
         # --- investigate large values
         for i in xrange(len(values_up)):

--- a/Tools/python/run_systematics.py
+++ b/Tools/python/run_systematics.py
@@ -526,7 +526,7 @@ def getTotalSystematicsPrediction(SearchBinObject, CRBinObject, N, S, runMap, sy
     if doRun2:
         moreSyst = [syst for syst in systHistoMap["search"]["lowdm"]]
         allSyst += moreSyst
-    systValMap = {syst:{"up" : [], "down" : [], "pred" : [], "pred_error_propagated" : []} for syst in allSyst}
+    systValMap = {syst:{"up" : [], "down" : [], "pred" : [], "pred_up" : [], "pred_down" : [], "pred_error_propagated" : []} for syst in allSyst}
 
     for region in regions:
         offset = 0
@@ -665,6 +665,8 @@ def getTotalSystematicsPrediction(SearchBinObject, CRBinObject, N, S, runMap, sy
                     systValMap[key]["up"].append(np.exp(abs(np.log(log_syst_up))))
                     systValMap[key]["down"].append(np.exp(abs(np.log(log_syst_down))))
                     systValMap[key]["pred"].append(p)
+                    systValMap[key]["pred_up"].append(p_up)
+                    systValMap[key]["pred_down"].append(p_down)
                     systValMap[key]["pred_error_propagated"].append(pred_error_propagated)
                 # these syst. are only available when doing Run 2
                 if doRun2:
@@ -698,6 +700,8 @@ def getTotalSystematicsPrediction(SearchBinObject, CRBinObject, N, S, runMap, sy
                         systValMap[syst]["up"].append(np.exp(abs(np.log(log_syst_up))))
                         systValMap[syst]["down"].append(np.exp(abs(np.log(log_syst_down))))
                         systValMap[syst]["pred"].append(p)
+                        systValMap[syst]["pred_up"].append(p_up)
+                        systValMap[syst]["pred_down"].append(p_down)
                         systValMap[syst]["pred_error_propagated"].append(pred_error_propagated)
 
 
@@ -759,6 +763,8 @@ def getTotalSystematicsPrediction(SearchBinObject, CRBinObject, N, S, runMap, sy
         values_up               = systValMap[syst]["up"]
         values_down             = systValMap[syst]["down"]
         pred                    = systValMap[syst]["pred"]
+        pred_up                 = systValMap[syst]["pred_up"]
+        pred_down               = systValMap[syst]["pred_down"]
         pred_error_propagated   = systValMap[syst]["pred_error_propagated"]
         print "Recording systematic {0}".format(syst)
 
@@ -783,9 +789,9 @@ def getTotalSystematicsPrediction(SearchBinObject, CRBinObject, N, S, runMap, sy
         for i in xrange(len(values_up)):
             maxVal = 2.0
             if values_up[i] >= maxVal: 
-                print "LargeSyst: {0}, {1}, bin {2}, syst_up = {3}; pred = {4} +/- {5}".format(era, syst, i, values_up[i], pred[i], pred_error_propagated[i])
+                print "LargeSyst: {0}, {1}, bin {2}, pred = {3} +/- {4}, pred_up = {5}, syst_up = {6}".format(era, syst, i, pred[i], pred_error_propagated[i], pred_up[i], values_up[i])
             if values_down[i] >= maxVal: 
-                print "LargeSyst: {0}, {1}, bin {2}, syst_down = {3}; pred = {4} +/- {5}".format(era, syst, i, values_down[i], pred[i], pred_error_propagated[i])
+                print "LargeSyst: {0}, {1}, bin {2}, pred = {3} +/- {4}, pred_down = {5}, syst_down = {6}".format(era, syst, i, pred[i], pred_error_propagated[i], pred_down[i], values_down[i])
 
         # --- plot 1D histograms
         h_up    = ROOT.TH1F("h_up",   "h_up",   100, 1.0, 3.0)

--- a/Tools/python/run_systematics.py
+++ b/Tools/python/run_systematics.py
@@ -689,16 +689,16 @@ def getTotalSystematicsPrediction(SearchBinObject, CRBinObject, N, S, runMap, sy
                     if value_up > 0 and value_up != 1:
                         # take inverse if value is less than 1
                         if value_up < 1:
-                            #value_up = 1.0 / value_up
-                            value_up = 1.0 + abs(1.0 - value_up)
+                            value_up = 1.0 / value_up
+                            #value_up = 1.0 + abs(1.0 - value_up)
                         # set limit of 200% on systematic
                         if value_up < 3.0:
                             useValUp = True
                     if value_down > 0 and value_down != 1:
                         # take inverse if value is less than 1
                         if value_down < 1:
-                            #value_down = 1.0 / value_down
-                            value_down = 1.0 + abs(1.0 - value_down)
+                            value_down = 1.0 / value_down
+                            #value_down = 1.0 + abs(1.0 - value_down)
                         # set limit of 200% on systematic
                         if value_down < 3.0:
                             useValDown = True
@@ -762,16 +762,16 @@ def getTotalSystematicsPrediction(SearchBinObject, CRBinObject, N, S, runMap, sy
                         if value_up > 0 and value_up != 1:
                             # take inverse if value is less than 1
                             if value_up < 1:
-                                #value_up = 1.0 / value_up
-                                value_up = 1.0 + abs(1.0 - value_up)
+                                value_up = 1.0 / value_up
+                                #value_up = 1.0 + abs(1.0 - value_up)
                             # set limit of 200% on systematic
                             if value_up < 3.0:
                                 useValUp = True
                         if value_down > 0 and value_down != 1:
                             # take inverse if value is less than 1
                             if value_down < 1:
-                                #value_down = 1.0 / value_down
-                                value_down = 1.0 + abs(1.0 - value_down)
+                                value_down = 1.0 / value_down
+                                #value_down = 1.0 + abs(1.0 - value_down)
                             # set limit of 200% on systematic
                             if value_down < 3.0:
                                 useValDown = True

--- a/Tools/python/run_systematics.py
+++ b/Tools/python/run_systematics.py
@@ -689,14 +689,16 @@ def getTotalSystematicsPrediction(SearchBinObject, CRBinObject, N, S, runMap, sy
                     if value_up > 0 and value_up != 1:
                         # take inverse if value is less than 1
                         if value_up < 1:
-                            value_up = 1.0 / value_up
+                            #value_up = 1.0 / value_up
+                            value_up = 1.0 + abs(1.0 - value_up)
                         # set limit of 200% on systematic
                         if value_up < 3.0:
                             useValUp = True
                     if value_down > 0 and value_down != 1:
                         # take inverse if value is less than 1
                         if value_down < 1:
-                            value_down = 1.0 / value_down
+                            #value_down = 1.0 / value_down
+                            value_down = 1.0 + abs(1.0 - value_down)
                         # set limit of 200% on systematic
                         if value_down < 3.0:
                             useValDown = True
@@ -760,14 +762,16 @@ def getTotalSystematicsPrediction(SearchBinObject, CRBinObject, N, S, runMap, sy
                         if value_up > 0 and value_up != 1:
                             # take inverse if value is less than 1
                             if value_up < 1:
-                                value_up = 1.0 / value_up
+                                #value_up = 1.0 / value_up
+                                value_up = 1.0 + abs(1.0 - value_up)
                             # set limit of 200% on systematic
                             if value_up < 3.0:
                                 useValUp = True
                         if value_down > 0 and value_down != 1:
                             # take inverse if value is less than 1
                             if value_down < 1:
-                                value_down = 1.0 / value_down
+                                #value_down = 1.0 / value_down
+                                value_down = 1.0 + abs(1.0 - value_down)
                             # set limit of 200% on systematic
                             if value_down < 3.0:
                                 useValDown = True

--- a/Tools/python/run_systematics.py
+++ b/Tools/python/run_systematics.py
@@ -684,18 +684,22 @@ def getTotalSystematicsPrediction(SearchBinObject, CRBinObject, N, S, runMap, sy
                     # values to estimate systematic ranges
                     value_up        = log_syst_up
                     value_down      = log_syst_down
-                    useValUp   = False
-                    useValDown = False
+                    useValUp        = False
+                    useValDown      = False
                     if value_up > 0 and value_up != 1:
-                        useValUp = True
                         # take inverse if value is less than 1
                         if value_up < 1:
                             value_up = 1.0 / value_up
+                        # set limit of 200% on systematic
+                        if value_up < 3.0:
+                            useValUp = True
                     if value_down > 0 and value_down != 1:
-                        useValDown = True
                         # take inverse if value is less than 1
                         if value_down < 1:
                             value_down = 1.0 / value_down
+                        # set limit of 200% on systematic
+                        if value_down < 3.0:
+                            useValDown = True
                     
                     # avoid taking log of negative number or 0
                     if log_syst_up <= 0:
@@ -751,18 +755,22 @@ def getTotalSystematicsPrediction(SearchBinObject, CRBinObject, N, S, runMap, sy
                         # values to estimate systematic ranges
                         value_up        = log_syst_up
                         value_down      = log_syst_down
-                        useValUp   = False
-                        useValDown = False
+                        useValUp        = False
+                        useValDown      = False
                         if value_up > 0 and value_up != 1:
-                            useValUp = True
                             # take inverse if value is less than 1
                             if value_up < 1:
                                 value_up = 1.0 / value_up
+                            # set limit of 200% on systematic
+                            if value_up < 3.0:
+                                useValUp = True
                         if value_down > 0 and value_down != 1:
-                            useValDown = True
                             # take inverse if value is less than 1
                             if value_down < 1:
                                 value_down = 1.0 / value_down
+                            # set limit of 200% on systematic
+                            if value_down < 3.0:
+                                useValDown = True
                         # avoid taking log of negative number or 0
                         if log_syst_up <= 0:
                             new_value = abs(ERROR_SYST * p)
@@ -911,7 +919,7 @@ def getTotalSystematicsPrediction(SearchBinObject, CRBinObject, N, S, runMap, sy
         
 
     # estimate ranges
-    infoFile.write("--- estimated ranges ---\n")
+    infoFile.write("--- estimated systematic ranges ---\n")
     for syst in systValMap:
         # Find the mean and standard deviation of the resulting set of numbers.
         # Now report exp(mean - std) and exp(mean + std) as the lower and upper ends of the range.

--- a/Tools/python/run_systematics.py
+++ b/Tools/python/run_systematics.py
@@ -793,6 +793,7 @@ def getTotalSystematicsPrediction(SearchBinObject, CRBinObject, N, S, runMap, sy
         name = "{0}_systDistribution_{1}".format("search", syst)
         title = "Z to Invisible: syst. distribution " + name + " for " + era
         x_title = "systematic"
+        y_title = "number of search bins"
 
         # setupHist(h_up,     title, x_title, "number of search bins",  color_red,    0.0, 200.0)
         # setupHist(h_down,   title, x_title, "number of search bins",  color_blue,   0.0, 200.0)
@@ -814,8 +815,8 @@ def getTotalSystematicsPrediction(SearchBinObject, CRBinObject, N, S, runMap, sy
         # --- plot 1D histograms using tools.plot()
         histograms = [h_up, h_down]
         labels = ["syst_up", "syst_down"]
-        # tools.plot(histograms, labels, name, title, x_title, x_min, x_max, y_min, y_max, era, plot_dir, showStats=False, normalize=False, setLog=False)
-        tplot(histograms, labels, name, title, x_title, 1.0, 3.0, 0.0, 200.0, era, out_dir, showStats=True)
+        # tools.plot(histograms, labels, name, title, x_title, y_title, x_min, x_max, y_min, y_max, era, plot_dir, showStats=False, normalize=False, setLog=False)
+        tplot(histograms, labels, name, title, x_title, y_title, 1.0, 3.0, 0.0, 200.0, era, out_dir, showStats=True)
         
         # del c
         del histograms

--- a/Tools/python/run_systematics.py
+++ b/Tools/python/run_systematics.py
@@ -746,6 +746,8 @@ def getTotalSystematicsPrediction(SearchBinObject, CRBinObject, N, S, runMap, sy
         del c
 
     # --- record systematic averages and ranges
+    medianList = [] 
+    infoFile.write("--- systematics ---\n")
     for syst in systValMap:
         values_up   = systValMap[syst]["up"]
         values_down = systValMap[syst]["down"]
@@ -760,6 +762,10 @@ def getTotalSystematicsPrediction(SearchBinObject, CRBinObject, N, S, runMap, sy
         min_down = 100 * (min(values_down) - 1)
         max_up   = 100 * (max(values_up) - 1)
         max_down = 100 * (max(values_down) - 1)
+        # list of medians (average over up/down)
+        med = np.mean([med_up, med_down])
+        medianList.append((syst, med))
+        
         # record average systematic here
         infoFile.write("{0}  {1}_Up    ave={2:.3f}%, med={3:.3f}%, range=[{4:.3f}%, {5:.3f}%]\n".format("total", syst, ave_up,   med_up,   min_up,   max_up   ))
         infoFile.write("{0}  {1}_Down  ave={2:.3f}%, med={3:.3f}%, range=[{4:.3f}%, {5:.3f}%]\n".format("total", syst, ave_down, med_down, min_down, max_down ))
@@ -771,6 +777,14 @@ def getTotalSystematicsPrediction(SearchBinObject, CRBinObject, N, S, runMap, sy
                 print "LargeSyst: {0}, {1}, bin {2}, syst_up = {3}".format(era, syst, i, values_up[i])
             if values_down[i] >= maxVal: 
                 print "LargeSyst: {0}, {1}, bin {2}, syst_down = {3}".format(era, syst, i, values_down[i])
+
+    # sort by median, greatest to least
+    medianArray = np.array(medianList, dtype=[('x', 'S30'), ('y', float)])
+    medianArray[::-1].sort(order='y')
+
+    infoFile.write("--- sorted by median ---\n")
+    for x in medianArray:
+        infoFile.write("{0}  {1}  med={2:.3f}%\n".format("total", x[0], x[1]))
 
     f_out.Close()
 

--- a/Tools/python/run_systematics.py
+++ b/Tools/python/run_systematics.py
@@ -1055,6 +1055,7 @@ def run(era, eras, runs_json, syst_json, doRun2, splitBtag, verbose):
     if era != "2018":
         systematics_znunu.append("prefire")
         systematics_phocr.append("prefire")
+        systematics_map["prefire"] = {"znunu" : "prefire", "phocr" : "prefire"}
     systematics = list(set(systematics_znunu) | set(systematics_phocr))
 
     varTagMap = {

--- a/Tools/python/run_systematics.py
+++ b/Tools/python/run_systematics.py
@@ -475,6 +475,19 @@ def getTotalSystematics(BinObject, bintype, systematics_znunu, systHistoMap, his
 #-------------------------------------------------------
 
 def getTotalSystematicsPrediction(SearchBinObject, CRBinObject, N, S, runMap, systematics_map, systHistoMap, histo, syst_histo, era, directions, regions, out_dir, infoFile, doRun2):
+    # colors
+    color_red    = "vermillion"
+    color_blue   = "electric blue"
+    color_green  = "irish green" 
+    color_purple = "violet"
+    color_black  = "black"
+         
+    # legend: TLegend(x1,y1,x2,y2)
+    legend_x1 = 0.6
+    legend_x2 = 0.9 
+    legend_y1 = 0.7
+    legend_y2 = 0.9 
+
     d = runMap[era]
     r  = "condor/" + d + "/result.root"
     N.getNormAndError(r, era)
@@ -707,18 +720,6 @@ def getTotalSystematicsPrediction(SearchBinObject, CRBinObject, N, S, runMap, sy
         
         eraTag = "_" + era
         draw_option = "hist"
-        # colors
-        color_red    = "vermillion"
-        color_blue   = "electric blue"
-        color_green  = "irish green" 
-        color_purple = "violet"
-        color_black  = "black"
-        
-        # legend: TLegend(x1,y1,x2,y2)
-        legend_x1 = 0.6
-        legend_x2 = 0.9 
-        legend_y1 = 0.7
-        legend_y2 = 0.9 
     
         c = ROOT.TCanvas("c", "c", 800, 800)
         name = "{0}_{1}".format("search", mySyst)
@@ -777,6 +778,39 @@ def getTotalSystematicsPrediction(SearchBinObject, CRBinObject, N, S, runMap, sy
                 print "LargeSyst: {0}, {1}, bin {2}, syst_up = {3}".format(era, syst, i, values_up[i])
             if values_down[i] >= maxVal: 
                 print "LargeSyst: {0}, {1}, bin {2}, syst_down = {3}".format(era, syst, i, values_down[i])
+        
+        # --- plot 1D histograms
+        c = ROOT.TCanvas("c", "c", 800, 800)
+        
+        h_up    = ROOT.TH1F("h_up",   "h_up",   100, 1.0, 3.0)
+        h_down  = ROOT.TH1F("h_down", "h_down", 100, 1.0, 3.0)
+        
+        for i in xrange(len(values_up)):
+            h_up.Fill(values_up[i])
+            h_down.Fill(values_down[i])
+        
+        name = "{0}_systDistribution_{1}".format("search", syst)
+        title = "Z to Invisible: syst. distribution " + name + " for " + era
+        x_title = "systematic"
+        setupHist(h_up,     title, x_title, "number of search bins",  color_red,    0.0, 200.0)
+        setupHist(h_down,   title, x_title, "number of search bins",  color_blue,   0.0, 200.0)
+        
+        h_up.Draw(draw_option)
+        h_down.Draw(draw_option + " same")
+        
+        # legend: TLegend(x1,y1,x2,y2)
+        legend = ROOT.TLegend(legend_x1, legend_y1, legend_x2, legend_y2)
+        legend.AddEntry(h_up,           "syst up",                  "l")
+        legend.AddEntry(h_down,         "syst down",                "l")
+        legend.Draw()
+        
+        # save histograms
+        plot_name = out_dir + name + eraTag
+        c.Update()
+        c.SaveAs(plot_name + ".png")
+        del c
+        del h_up
+        del h_down
 
     # sort by median, greatest to least
     medianArray = np.array(medianList, dtype=[('x', 'S30'), ('y', float)])

--- a/Tools/python/tools.py
+++ b/Tools/python/tools.py
@@ -321,7 +321,7 @@ def getMatrixInverseError(A, A_error):
     Ainverse_error[1][1] = getMultiplicationError( A[0][0] / det,  A[0][0], A_error[0][0], det, det_error)
     return Ainverse_error
 
-def plot(histograms, labels, name, title, x_title, x_min, x_max, y_min, y_max, era, plot_dir, showStats=False, normalize=False, setLog=False):
+def plot(histograms, labels, name, title, x_title, y_title, x_min, x_max, y_min, y_max, era, plot_dir, showStats=False, normalize=False, setLog=False):
     eraTag = "_" + era
     draw_option = "hist"
             
@@ -342,8 +342,6 @@ def plot(histograms, labels, name, title, x_title, x_min, x_max, y_min, y_max, e
     
     c = ROOT.TCanvas("c", "c", 800, 800)
 
-    y_title = "Events"
-    
     for i in xrange(len(histograms)):
         # normalize
         if normalize:

--- a/Tools/python/tools.py
+++ b/Tools/python/tools.py
@@ -321,7 +321,7 @@ def getMatrixInverseError(A, A_error):
     Ainverse_error[1][1] = getMultiplicationError( A[0][0] / det,  A[0][0], A_error[0][0], det, det_error)
     return Ainverse_error
 
-def plot(histograms, labels, name, title, x_title, x_min, x_max, y_min, y_max, era, showStats=False, normalize=False, setLog=False):
+def plot(histograms, labels, name, title, x_title, x_min, x_max, y_min, y_max, era, plot_dir, showStats=False, normalize=False, setLog=False):
     eraTag = "_" + era
     draw_option = "hist"
             
@@ -381,7 +381,8 @@ def plot(histograms, labels, name, title, x_title, x_min, x_max, y_min, y_max, e
             mark.DrawLatex(x_pos_2, y_list[2 * i + 1], "\mu = %.3f, \sigma = %.3f" % (histograms[i].GetMean(), histograms[i].GetStdDev()))
 
     # save histograms
-    plot_dir = "more_plots/"
+    if plot_dir[-1] != "/":
+        plot_dir += "/"
     plot_name = plot_dir + name + eraTag
     c.Update()
     c.SaveAs(plot_name + ".png")


### PR DESCRIPTION
- Compare v6p5 and v7 results
- Plot distributions of systematic values
- Estimate systematic ranges using procedure from @jsw-fnal

Procedure from @jsw-fnal: 
For each systematic, we have an "Up" and "Down" ratio for each search bin.  For those ratios that are less than 1, take the reciprocal.  Drop any that are exactly equal to 1 (because that indicates the systematic is "off" or ignored in that bin).  Now we have a collection of numbers that are all strictly greater than 1.  Subtract 1 from them.  Take the logarithm.  Find the mean and standard deviation of the resulting set of numbers.  Now report exp(mean - std) and exp(mean + std) as the lower and upper ends of the range.