### PR TITLE
Adjust Z vs Photon Plots

### DIFF
--- a/Tools/MakePlots.C
+++ b/Tools/MakePlots.C
@@ -530,6 +530,8 @@ int main(int argc, char* argv[])
     std::string label_metphi = "#phi_{MET}";
     std::string label_metphiWithLL = "#phi_{MET}^{ll}";
     std::string label_metphiWithPhoton = "#phi_{MET}^{#gamma}";
+    //std::string label_bestRecoZM  = "m_{#ell#ell} [GeV]";   // does not work
+    //std::string label_bestRecoZM  = "m_{\\ell\\ell} [GeV]"; // works only for png, but not pdf 
     std::string label_bestRecoZM  = "m_{ll} [GeV]";
     std::string label_bestRecoZPt = "p_{T}(ll) [GeV]";
     std::string label_ht  = "H_{T} [GeV]";

--- a/Tools/Plotter.cc
+++ b/Tools/Plotter.cc
@@ -903,15 +903,15 @@ void Plotter::plot()
         //double leg_y1 = 0.88 - NlegEntries * 0.045;
         //double leg_y2 = 0.88;
         // modified (good for lepton CR plots)
-        //double leg_x1 = 0.50 + leg_x_offset;
-        //double leg_x2 = 0.89 + leg_x_offset;
-        //double leg_y1 = 0.89 - NlegEntries * 0.06;
-        //double leg_y2 = 0.89;
-        // modified (good for photon CR plots)
-        double leg_x1 = 0.50;
-        double leg_x2 = 0.89;
-        double leg_y1 = 0.89 - NlegEntries * 0.045;
+        double leg_x1 = 0.50 + leg_x_offset;
+        double leg_x2 = 0.89 + leg_x_offset;
+        double leg_y1 = 0.89 - NlegEntries * 0.06;
         double leg_y2 = 0.89;
+        // modified (good for photon CR plots)
+        //double leg_x1 = 0.50;
+        //double leg_x2 = 0.89;
+        //double leg_y1 = 0.89 - NlegEntries * 0.045;
+        //double leg_y2 = 0.89;
 
         TLegend *leg = new TLegend(leg_x1, leg_y1, leg_x2, leg_y2);
         leg->SetFillStyle(0);

--- a/Tools/Plotter.cc
+++ b/Tools/Plotter.cc
@@ -1291,27 +1291,38 @@ void Plotter::plot()
         TLatex mark;
         mark.SetNDC(true);
 
-        //Draw CMS mark
+        //Drawing text
         double x_offset = 0.0;
-        mark.SetTextAlign(11);
-        mark.SetTextSize(0.042 * fontScale * 1.25);
-        //mark.SetTextSize(0.04 * 1.1 * 8 / 6.5 * 1.25 * fontScale);
-        mark.SetTextFont(61);
-        //mark.DrawLatex(gPad->GetLeftMargin(), 1 - (gPad->GetTopMargin() - 0.017), "CMS"); // #scale[0.8]{#it{Preliminary}}");
-        mark.DrawLatex(gPad->GetLeftMargin() + x_offset, 1 - (gPad->GetTopMargin() - 0.017), "CMS");
-        mark.SetTextSize(0.042 * fontScale);
-        //mark.SetTextSize(0.04 * 1.1 * 8 / 6.5 * fontScale);
-        mark.SetTextFont(52);
-        //mark.DrawLatex(gPad->GetLeftMargin() + x_offset + 0.095, 1 - (gPad->GetTopMargin() - 0.017), "Preliminary");
-        mark.DrawLatex(gPad->GetLeftMargin() + x_offset + 0.095, 1 - (gPad->GetTopMargin() - 0.017), "Supplementary");
+        double y_position_1 = 1 - (gPad->GetTopMargin() - 0.017);
+        double y_position_2 = 1 - (gPad->GetTopMargin() + 0.075);
         
-        //mark.DrawLatex(gPad->GetLeftMargin() + 0.095, 1 - (gPad->GetTopMargin() - 0.017), "Preliminary");
-        //mark.DrawLatex(gPad->GetLeftMargin() + 0.095, 1 - (gPad->GetTopMargin() - 0.017), "Supplementary");
+        //Draw CMS mark
+        mark.SetTextAlign(11); // Left adjusted (left aligned)
+        mark.SetTextFont(62);
+        //mark.SetTextSize(0.04 * 1.1 * 8 / 6.5 * 1.25 * fontScale);
+        mark.SetTextSize(0.042 * fontScale * 1.25);
+        //mark.DrawLatex(gPad->GetLeftMargin(), 1 - (gPad->GetTopMargin() - 0.017), "CMS"); // #scale[0.8]{#it{Preliminary}}");
+        mark.DrawLatex(gPad->GetLeftMargin() + x_offset, y_position_1, "CMS");
+        
+        //Draw type (e.g. Preliminary, Supplementary, etc.)
+        mark.SetTextAlign(11); // Left adjusted (left aligned)
+        mark.SetTextFont(52);
+        //mark.SetTextSize(0.04 * 1.1 * 8 / 6.5 * fontScale);
+        mark.SetTextSize(0.042 * fontScale);
+        //mark.DrawLatex(gPad->GetLeftMargin() + x_offset + 0.095, 1 - (gPad->GetTopMargin() - 0.017), "Preliminary");
+        mark.DrawLatex(gPad->GetLeftMargin() + x_offset + 0.095, y_position_1, "Supplementary");
 
         //Draw lumistamp
+        mark.SetTextAlign(31); // Right adjusted (right aligned)
         mark.SetTextFont(42);
-        mark.SetTextAlign(31);
-        mark.DrawLatex(1 - gPad->GetRightMargin(), 1 - (gPad->GetTopMargin() - 0.017), lumistamp);
+        mark.SetTextSize(0.042 * fontScale);
+        mark.DrawLatex(1 - gPad->GetRightMargin(), y_position_1, lumistamp);
+
+        //Draw arXiv number: arXiv:2103.01290 
+        mark.SetTextAlign(11); // Left adjusted (left aligned)
+        mark.SetTextFont(42);
+        mark.SetTextSize(0.042 * fontScale);
+        mark.DrawLatex(gPad->GetLeftMargin() + x_offset + 0.030, y_position_2, "arXiv:2103.01290");
 
         //Write comment on normalization
         //if(hist.isNorm)

--- a/Tools/python/systematics.py
+++ b/Tools/python/systematics.py
@@ -347,7 +347,7 @@ class Systematic:
             # turn off x-axis titles for upper plot
             # setupHist(hist, title, x_title, y_title, color, y_min, y_max, adjust=False, lineWidth=5, turnOffStats=True)
             setupHist(h_ratio_num,          title, "",      y_title,       num_color,         y_min,        y_max,        True,  1)
-            setupHist(h_ratio_den,          title, "",      y_title,       "electric blue",   y_min,        y_max,        True,  1)
+            setupHist(h_ratio_den,          title, "",      y_title,       "electric blue",   y_min,        y_max,        True,  2)
             setupHist(h_ratio_ZoverPhoton,  title, x_title, ratio_title,   "black",           ratio_y_min,  ratio_y_max,  True,  1)
             h_ratio_num.GetXaxis().SetRangeUser(self.x_min, self.x_max)
             h_ratio_den.GetXaxis().SetRangeUser(self.x_min, self.x_max)

--- a/Tools/python/systematics.py
+++ b/Tools/python/systematics.py
@@ -398,12 +398,32 @@ class Systematic:
                     self.h_map_syst[region] = copy.deepcopy(h_syst)
             
             # Uncertainties
-            unc = ROOT.TGraphAsymmErrors(h_ratio_den)
+            #unc = ROOT.TGraphAsymmErrors(h_ratio_den)
+            #unc = ROOT.TGraph(h_ratio_den)
+            
+            # manually create TGraph
+            nBins = h_ratio_den.GetNbinsX()
+            xVals = []
+            yVals = []
+            for n in range(1, nBins + 1):
+                xVals.append(h_ratio_den.GetBinCenter(n))
+                yVals.append(h_ratio_den.GetBinContent(n))
+            xVals = np.array(xVals)
+            yVals = np.array(yVals)
+            unc = ROOT.TGraph(nBins, xVals, yVals)
+            
             unc.SetFillColor(getColorIndex("electric blue"))
             unc.SetFillStyle(3013)
-            unc.SetLineStyle(0)
-            unc.SetLineWidth(0)
-            unc.SetMarkerSize(0)
+            
+            #unc.SetLineStyle(0)
+            #unc.SetLineWidth(0)
+            #unc.SetMarkerSize(0)
+            
+            unc.SetLineColor(ROOT.kRed)
+            unc.SetLineWidth(3)
+            unc.SetMarkerStyle(ROOT.kFullSquare)
+            unc.SetMarkerColor(ROOT.kRed)
+            unc.SetMarkerSize(2)
 
             # pad for histograms
             pad = c.cd(1)
@@ -417,15 +437,35 @@ class Systematic:
             pad.SetRightMargin(0.1)
             pad.SetTopMargin(0.1)
             pad.SetBottomMargin(0.01)
+
+            # --- testing ---
+
+            for n in range(1, h_ratio_den.GetNbinsX() + 1):
+                print "h_ratio_den_{0}_{1}_{2}: bin: {3}, content: {4}, error: {5}".format(era, var, region, n, h_ratio_den.GetBinContent(n), h_ratio_den.GetBinError(n))
             
-            # draw
-            h_ratio_den.Draw(draw_option)
-            unc.Draw("E2 same")
-            if doDataOverData:
-                h_ratio_num.SetMarkerStyle(ROOT.kFullDotLarge)
-                h_ratio_num.Draw(data_style + " same")
-            else:
-                h_ratio_num.Draw(draw_option + " same")
+            #print "TGraphAsymmErrors_{0}: unc.GetN(): {1}".format(era, unc.GetN())
+            #for n in range(1, unc.GetN() + 1):
+            #    print "TGraphAsymmErrors_{0}: bin: {1}, x: {2}, y: {3}, x_error: {4}, y_error: {5}".format(era, n, unc.GetPointX(n), unc.GetPointY(n), unc.GetErrorX(n), unc.GetErrorY(n))
+            
+            print "TGraph_{0}: unc.GetN(): {1}".format(era, unc.GetN())
+            for n in range(1, unc.GetN() + 1):
+                print "TGraph_{0}: bin: {1}, x: {2}, y: {3}, x_error: {4}, y_error: {5}".format(era, n, unc.GetPointX(n), unc.GetPointY(n), unc.GetErrorX(n), unc.GetErrorY(n))
+            
+            # --- draw --- 
+            
+            # testing
+            #unc.Draw("P0Z")
+            unc.Draw("E1")
+            
+            #h_ratio_den.Draw(draw_option)
+            #unc.Draw("E2 same")
+            #unc.Draw("E1 same")
+            #if doDataOverData:
+            #    h_ratio_num.SetMarkerStyle(ROOT.kFullDotLarge)
+            #    h_ratio_num.Draw(data_style + " same")
+            #else:
+            #    h_ratio_num.Draw(draw_option + " same")
+            
             # legend: TLegend(x1,y1,x2,y2)
             legend_x1 = 0.60
             legend_x2 = 0.90

--- a/Tools/python/systematics.py
+++ b/Tools/python/systematics.py
@@ -253,8 +253,12 @@ class Systematic:
     # double ratio: Z (data/MC) over Photon (data/MC), or data (Z/Photon) over MC (Z/Photon)
     def makeZvsPhoton(self, file_name, var, varPhoton, varLepton, era, x_min, x_max, n_bins=0, xbins=np.array([]), rebin=False, useForSyst=False, doDataOverData=False):
         doFit = False
-        draw_option = "hist error"
-        data_style  = "E1"
+        #draw_option = "hist error"
+        #draw_option = "hist E2"
+        #draw_option = "hist E4"
+        draw_option = "hist"
+        #data_style  = "E1"
+        data_style  = "PZ0"
         drawSyst = (era == "Run2") and (not doDataOverData)
         ROOT.gStyle.SetErrorX(0) # remove horizontal bar for data points
         
@@ -397,6 +401,14 @@ class Systematic:
                 if useForSyst:
                     self.h_map_syst[region] = copy.deepcopy(h_syst)
             
+            # Uncertainties
+            unc = ROOT.TGraphAsymmErrors(h_ratio_den)
+            unc.SetFillColor(getColorIndex("electric blue"))
+            unc.SetFillStyle(3013)
+            unc.SetLineStyle(0)
+            unc.SetLineWidth(0)
+            unc.SetMarkerSize(0)
+
             # pad for histograms
             pad = c.cd(1)
             # resize pad
@@ -412,8 +424,10 @@ class Systematic:
             
             # draw
             h_ratio_den.Draw(draw_option)
+            unc.Draw("E2 same")
             if doDataOverData:
-                h_ratio_num.SetMarkerStyle(ROOT.kFullCircle)
+                #h_ratio_num.SetMarkerStyle(ROOT.kFullCircle)
+                h_ratio_num.SetMarkerStyle(ROOT.kFullDotLarge)
                 h_ratio_num.Draw(data_style + " same")
             else:
                 h_ratio_num.Draw(draw_option + " same")
@@ -482,7 +496,8 @@ class Systematic:
             
             # draw
             if doDataOverData:
-                h_ratio_ZoverPhoton.SetMarkerStyle(ROOT.kFullCircle)
+                #h_ratio_ZoverPhoton.SetMarkerStyle(ROOT.kFullCircle)
+                h_ratio_ZoverPhoton.SetMarkerStyle(ROOT.kFullDotLarge)
                 h_ratio_ZoverPhoton.Draw(data_style)
             else:
                 h_ratio_ZoverPhoton.Draw(draw_option)

--- a/Tools/python/systematics.py
+++ b/Tools/python/systematics.py
@@ -399,18 +399,21 @@ class Systematic:
             
             # Uncertainties
             #unc = ROOT.TGraphAsymmErrors(h_ratio_den)
+            unc = ROOT.TGraphErrors(h_ratio_den)
             #unc = ROOT.TGraph(h_ratio_den)
             
+            setupHist(unc, title, x_title, ratio_title, "electric blue", ratio_y_min, ratio_y_max, True, 3, False)
+            
             # manually create TGraph
-            nBins = h_ratio_den.GetNbinsX()
-            xVals = []
-            yVals = []
-            for n in range(1, nBins + 1):
-                xVals.append(h_ratio_den.GetBinCenter(n))
-                yVals.append(h_ratio_den.GetBinContent(n))
-            xVals = np.array(xVals)
-            yVals = np.array(yVals)
-            unc = ROOT.TGraph(nBins, xVals, yVals)
+            #nBins = h_ratio_den.GetNbinsX()
+            #xVals = []
+            #yVals = []
+            #for n in range(1, nBins + 1):
+            #    xVals.append(h_ratio_den.GetBinCenter(n))
+            #    yVals.append(h_ratio_den.GetBinContent(n))
+            #xVals = np.array(xVals)
+            #yVals = np.array(yVals)
+            #unc = ROOT.TGraph(nBins, xVals, yVals)
             
             unc.SetFillColor(getColorIndex("electric blue"))
             unc.SetFillStyle(3013)
@@ -419,11 +422,11 @@ class Systematic:
             #unc.SetLineWidth(0)
             #unc.SetMarkerSize(0)
             
-            unc.SetLineColor(ROOT.kRed)
-            unc.SetLineWidth(3)
-            unc.SetMarkerStyle(ROOT.kFullSquare)
-            unc.SetMarkerColor(ROOT.kRed)
-            unc.SetMarkerSize(2)
+            #unc.SetLineColor(ROOT.kRed)
+            #unc.SetLineWidth(3)
+            #unc.SetMarkerStyle(ROOT.kFullSquare)
+            #unc.SetMarkerColor(ROOT.kRed)
+            #unc.SetMarkerSize(2)
 
             # pad for histograms
             pad = c.cd(1)
@@ -447,24 +450,23 @@ class Systematic:
             #for n in range(1, unc.GetN() + 1):
             #    print "TGraphAsymmErrors_{0}: bin: {1}, x: {2}, y: {3}, x_error: {4}, y_error: {5}".format(era, n, unc.GetPointX(n), unc.GetPointY(n), unc.GetErrorX(n), unc.GetErrorY(n))
             
-            print "TGraph_{0}: unc.GetN(): {1}".format(era, unc.GetN())
-            for n in range(1, unc.GetN() + 1):
-                print "TGraph_{0}: bin: {1}, x: {2}, y: {3}, x_error: {4}, y_error: {5}".format(era, n, unc.GetPointX(n), unc.GetPointY(n), unc.GetErrorX(n), unc.GetErrorY(n))
+            #print "TGraph_{0}: unc.GetN(): {1}".format(era, unc.GetN())
+            #for n in range(1, unc.GetN() + 1):
+            #    print "TGraph_{0}: bin: {1}, x: {2}, y: {3}, x_error: {4}, y_error: {5}".format(era, n, unc.GetPointX(n), unc.GetPointY(n), unc.GetErrorX(n), unc.GetErrorY(n))
             
             # --- draw --- 
             
             # testing
             #unc.Draw("P0Z")
-            unc.Draw("E1")
+            #unc.Draw("E1")
             
-            #h_ratio_den.Draw(draw_option)
-            #unc.Draw("E2 same")
-            #unc.Draw("E1 same")
-            #if doDataOverData:
-            #    h_ratio_num.SetMarkerStyle(ROOT.kFullDotLarge)
-            #    h_ratio_num.Draw(data_style + " same")
-            #else:
-            #    h_ratio_num.Draw(draw_option + " same")
+            h_ratio_den.Draw(draw_option)
+            unc.Draw("E2 same")
+            if doDataOverData:
+                h_ratio_num.SetMarkerStyle(ROOT.kFullDotLarge)
+                h_ratio_num.Draw(data_style + " same")
+            else:
+                h_ratio_num.Draw(draw_option + " same")
             
             # legend: TLegend(x1,y1,x2,y2)
             legend_x1 = 0.60

--- a/Tools/python/systematics.py
+++ b/Tools/python/systematics.py
@@ -254,7 +254,7 @@ class Systematic:
     def makeZvsPhoton(self, file_name, var, varPhoton, varLepton, era, x_min, x_max, n_bins=0, xbins=np.array([]), rebin=False, useForSyst=False, doDataOverData=False):
         doFit = False
         draw_option = "hist error"
-        data_style  = "E"
+        data_style  = "E1"
         drawSyst = (era == "Run2") and (not doDataOverData)
         ROOT.gStyle.SetErrorX(0) # remove horizontal bar for data points
         
@@ -440,19 +440,23 @@ class Systematic:
             width       = right - left
             mark_x1     = left + x_offset * width
             mark_x2     = left + (x_offset + 0.15) * width
-            mark_y      = 0.9 * y_max
+            mark_y1      = 0.90 * y_max
+            mark_y2      = 0.83 * y_max
             lumi_x      = right 
             lumi_y      = 1.02 * y_max
             
             # Draw CMS mark
             cms_mark = ROOT.TLatex()
             cms_mark.SetTextAlign(11) # left aligned
-            cms_mark.SetTextFont(61)
+            cms_mark.SetTextFont(62)
             cms_mark.SetTextSize(1.25 * font_scale)
-            cms_mark.DrawLatex(mark_x1, mark_y, "CMS")
+            cms_mark.DrawLatex(mark_x1, mark_y1, "CMS")
             cms_mark.SetTextFont(52)
             cms_mark.SetTextSize(font_scale)
-            cms_mark.DrawLatex(mark_x2, mark_y, "Supplementary")
+            cms_mark.DrawLatex(mark_x2, mark_y1, "Supplementary")
+            cms_mark.SetTextFont(42)
+            cms_mark.SetTextSize(font_scale)
+            cms_mark.DrawLatex(mark_x1, mark_y2, "arXiv:2103.01290")
 
             # Draw lumi stamp
             lumi = self.lumis[era]

--- a/Tools/python/systematics.py
+++ b/Tools/python/systematics.py
@@ -334,7 +334,6 @@ class Systematic:
                 chisq   = fit.GetChisquare()
                 chisq_r = chisq / nDegFree
             
-            
             # histogram info 
             # turn off title
             #title = "Z vs. Photon, {0}, {1}".format(region, era)
@@ -346,10 +345,10 @@ class Systematic:
                 x_title = self.labels[var]
             
             # turn off x-axis titles for upper plot
-            # setupHist(hist, title, x_title, y_title, color, y_min, y_max, adjust=False)
-            setupHist(h_ratio_num,          title, "",      y_title,       num_color,         y_min, y_max, True, 3)
-            setupHist(h_ratio_den,          title, "",      y_title,       "electric blue",   y_min, y_max, True, 3)
-            setupHist(h_ratio_ZoverPhoton,  title, x_title, ratio_title,   "black",           ratio_y_min, ratio_y_max, True, 3)
+            # setupHist(hist, title, x_title, y_title, color, y_min, y_max, adjust=False, lineWidth=5, turnOffStats=True)
+            setupHist(h_ratio_num,          title, "",      y_title,       num_color,         y_min,        y_max,        True,  1)
+            setupHist(h_ratio_den,          title, "",      y_title,       "electric blue",   y_min,        y_max,        True,  1)
+            setupHist(h_ratio_ZoverPhoton,  title, x_title, ratio_title,   "black",           ratio_y_min,  ratio_y_max,  True,  1)
             h_ratio_num.GetXaxis().SetRangeUser(self.x_min, self.x_max)
             h_ratio_den.GetXaxis().SetRangeUser(self.x_min, self.x_max)
             h_ratio_ZoverPhoton.GetXaxis().SetRangeUser(self.x_min, self.x_max)
@@ -397,16 +396,8 @@ class Systematic:
                 if useForSyst:
                     self.h_map_syst[region] = copy.deepcopy(h_syst)
             
-            # Uncertainties
-            #unc = ROOT.TGraphAsymmErrors(h_ratio_den)
-            #unc = ROOT.TGraphErrors(h_ratio_den)
-            #unc = ROOT.TGraph(h_ratio_den)
-            
-            #setupHist(unc, title, x_title, ratio_title, "electric blue", ratio_y_min, ratio_y_max, True, 3, False)
-            
             # manually create TGraphErrors
             
-            # version 1
             nBins = h_ratio_den.GetNbinsX()
             xVals = []
             yVals = []
@@ -417,26 +408,18 @@ class Systematic:
                 yVals.append(h_ratio_den.GetBinContent(n))
                 xErrors.append(h_ratio_den.GetBinWidth(n) / 2)
                 yErrors.append(h_ratio_den.GetBinError(n))
-            # np.array() is required
+            # np.array() is required for TGraphErrors constructor
             xVals = np.array(xVals)
             yVals = np.array(yVals)
             xErrors = np.array(xErrors)
             yErrors = np.array(yErrors)
             unc = ROOT.TGraphErrors(nBins, xVals, yVals, xErrors, yErrors)
-            
             unc.SetFillColor(getColorIndex("electric blue"))
             unc.SetFillStyle(3013)
-            
             unc.SetLineStyle(0)
             unc.SetLineWidth(0)
             unc.SetMarkerSize(0)
             
-            #unc.SetLineColor(ROOT.kRed)
-            #unc.SetLineWidth(3)
-            #unc.SetMarkerStyle(ROOT.kFullSquare)
-            #unc.SetMarkerColor(ROOT.kRed)
-            #unc.SetMarkerSize(2)
-
             # pad for histograms
             pad = c.cd(1)
             # resize pad
@@ -452,19 +435,8 @@ class Systematic:
 
             # --- testing ---
 
-
-            #for n in range(1, h_ratio_den.GetNbinsX() + 1):
-            #    print "h_ratio_den_{0}_{1}_{2}: bin: {3}, content: {4}, error: {5}".format(era, var, region, n, h_ratio_den.GetBinContent(n), h_ratio_den.GetBinError(n))
-            
-            #print "TGraphAsymmErrors_{0}: unc.GetN(): {1}".format(era, unc.GetN())
-            #for n in range(1, unc.GetN() + 1):
-            #    print "TGraphAsymmErrors_{0}: bin: {1}, x: {2}, y: {3}, x_error: {4}, y_error: {5}".format(era, n, unc.GetPointX(n), unc.GetPointY(n), unc.GetErrorX(n), unc.GetErrorY(n))
-            
-            # Error message: AttributeError: 'TGraph' object has no attribute 'GetPointX'
-            
-            #print "TGraph_{0}: unc.GetN(): {1}".format(era, unc.GetN())
-            #for n in range(1, unc.GetN() + 1):
-            #    print "TGraph_{0}: bin: {1}, x: {2}, y: {3}, x_error: {4}, y_error: {5}".format(era, n, unc.GetPointX(n), unc.GetPointY(n), unc.GetErrorX(n), unc.GetErrorY(n))
+            for n in range(1, h_ratio_den.GetNbinsX() + 1):
+                print "h_ratio_den_{0}_{1}_{2}: bin: {3}, content: {4}, error: {5}".format(era, var, region, n, h_ratio_den.GetBinContent(n), h_ratio_den.GetBinError(n))
             
             points_x = unc.GetX()
             points_y = unc.GetY()
@@ -473,11 +445,6 @@ class Systematic:
                 print "TGraph_{0}_{1}_{2}: bin: {3}, x: {4}, y: {5}, x_error: {6}, y_error: {7}".format(era, var, region, n, points_x[n-1], points_y[n-1], unc.GetErrorX(n), unc.GetErrorY(n))
             
             # --- draw --- 
-            
-            # testing
-            #unc.Draw("P0Z")
-            #unc.Draw("E1")
-            
             h_ratio_den.Draw(draw_option)
             unc.Draw("E2 same")
             if doDataOverData:

--- a/Tools/python/systematics.py
+++ b/Tools/python/systematics.py
@@ -400,21 +400,30 @@ class Systematic:
             # Uncertainties
             #unc = ROOT.TGraphAsymmErrors(h_ratio_den)
             #unc = ROOT.TGraphErrors(h_ratio_den)
-            unc = ROOT.TGraph(h_ratio_den)
+            #unc = ROOT.TGraph(h_ratio_den)
             
             #setupHist(unc, title, x_title, ratio_title, "electric blue", ratio_y_min, ratio_y_max, True, 3, False)
             
-            # manually create TGraph
-            #nBins = h_ratio_den.GetNbinsX()
-            #xVals = []
-            #yVals = []
-            #for n in range(1, nBins + 1):
-            #    xVals.append(h_ratio_den.GetBinCenter(n))
-            #    yVals.append(h_ratio_den.GetBinContent(n))
-            #xVals = np.array(xVals)
-            #yVals = np.array(yVals)
-            #unc = ROOT.TGraph(nBins, xVals, yVals)
-
+            # manually create TGraphErrors
+            
+            # version 1
+            nBins = h_ratio_den.GetNbinsX()
+            xVals = []
+            yVals = []
+            xErrors = []
+            yErrors = []
+            for n in range(1, nBins + 1):
+                xVals.append(h_ratio_den.GetBinCenter(n))
+                yVals.append(h_ratio_den.GetBinContent(n))
+                xErrors.append(h_ratio_den.GetBinWidth(n) / 2)
+                yErrors.append(h_ratio_den.GetBinError(n))
+            # np.array() is required
+            xVals = np.array(xVals)
+            yVals = np.array(yVals)
+            xErrors = np.array(xErrors)
+            yErrors = np.array(yErrors)
+            unc = ROOT.TGraphErrors(nBins, xVals, yVals, xErrors, yErrors)
+            
             unc.SetFillColor(getColorIndex("electric blue"))
             unc.SetFillStyle(3013)
             

--- a/Tools/python/systematics.py
+++ b/Tools/python/systematics.py
@@ -347,7 +347,7 @@ class Systematic:
             # turn off x-axis titles for upper plot
             # setupHist(hist, title, x_title, y_title, color, y_min, y_max, adjust=False, lineWidth=5, turnOffStats=True)
             setupHist(h_ratio_num,          title, "",      y_title,       num_color,         y_min,        y_max,        True,  1)
-            setupHist(h_ratio_den,          title, "",      y_title,       "electric blue",   y_min,        y_max,        True,  2)
+            setupHist(h_ratio_den,          title, "",      y_title,       "electric blue",   y_min,        y_max,        True,  3)
             setupHist(h_ratio_ZoverPhoton,  title, x_title, ratio_title,   "black",           ratio_y_min,  ratio_y_max,  True,  1)
             h_ratio_num.GetXaxis().SetRangeUser(self.x_min, self.x_max)
             h_ratio_den.GetXaxis().SetRangeUser(self.x_min, self.x_max)

--- a/Tools/python/systematics.py
+++ b/Tools/python/systematics.py
@@ -347,9 +347,9 @@ class Systematic:
             
             # turn off x-axis titles for upper plot
             # setupHist(hist, title, x_title, y_title, color, y_min, y_max, adjust=False)
-            setupHist(h_ratio_num,          title, "",      y_title,       num_color,         y_min, y_max, True)
-            setupHist(h_ratio_den,          title, "",      y_title,       "electric blue",   y_min, y_max, True)
-            setupHist(h_ratio_ZoverPhoton,  title, x_title, ratio_title,   "black",           ratio_y_min, ratio_y_max, True)
+            setupHist(h_ratio_num,          title, "",      y_title,       num_color,         y_min, y_max, True, 3)
+            setupHist(h_ratio_den,          title, "",      y_title,       "electric blue",   y_min, y_max, True, 3)
+            setupHist(h_ratio_ZoverPhoton,  title, x_title, ratio_title,   "black",           ratio_y_min, ratio_y_max, True, 3)
             h_ratio_num.GetXaxis().SetRangeUser(self.x_min, self.x_max)
             h_ratio_den.GetXaxis().SetRangeUser(self.x_min, self.x_max)
             h_ratio_ZoverPhoton.GetXaxis().SetRangeUser(self.x_min, self.x_max)

--- a/Tools/python/systematics.py
+++ b/Tools/python/systematics.py
@@ -253,11 +253,7 @@ class Systematic:
     # double ratio: Z (data/MC) over Photon (data/MC), or data (Z/Photon) over MC (Z/Photon)
     def makeZvsPhoton(self, file_name, var, varPhoton, varLepton, era, x_min, x_max, n_bins=0, xbins=np.array([]), rebin=False, useForSyst=False, doDataOverData=False):
         doFit = False
-        #draw_option = "hist error"
-        #draw_option = "hist E2"
-        #draw_option = "hist E4"
         draw_option = "hist"
-        #data_style  = "E1"
         data_style  = "PZ0"
         drawSyst = (era == "Run2") and (not doDataOverData)
         ROOT.gStyle.SetErrorX(0) # remove horizontal bar for data points
@@ -426,7 +422,6 @@ class Systematic:
             h_ratio_den.Draw(draw_option)
             unc.Draw("E2 same")
             if doDataOverData:
-                #h_ratio_num.SetMarkerStyle(ROOT.kFullCircle)
                 h_ratio_num.SetMarkerStyle(ROOT.kFullDotLarge)
                 h_ratio_num.Draw(data_style + " same")
             else:
@@ -497,7 +492,6 @@ class Systematic:
             
             # draw
             if doDataOverData:
-                #h_ratio_ZoverPhoton.SetMarkerStyle(ROOT.kFullCircle)
                 h_ratio_ZoverPhoton.SetMarkerStyle(ROOT.kFullDotLarge)
                 h_ratio_ZoverPhoton.Draw(data_style)
             else:

--- a/Tools/python/systematics.py
+++ b/Tools/python/systematics.py
@@ -432,10 +432,10 @@ class Systematic:
             else:
                 h_ratio_num.Draw(draw_option + " same")
             # legend: TLegend(x1,y1,x2,y2)
-            legend_x1 = 0.65
+            legend_x1 = 0.60
             legend_x2 = 0.90
-            legend_y1 = 0.73
-            legend_y2 = 0.88
+            legend_y1 = 0.65
+            legend_y2 = 0.85
             legend1 = ROOT.TLegend(legend_x1, legend_y1, legend_x2, legend_y2)
             legend1.SetFillStyle(0)
             legend1.SetBorderSize(0)
@@ -444,6 +444,7 @@ class Systematic:
             legend1.SetTextFont(42)
             legend1.AddEntry(h_ratio_num, num_label, num_legend_style)
             legend1.AddEntry(h_ratio_den, den_label, "l")
+            legend1.AddEntry(unc, "Stat. unc.", "F")
             legend1.Draw()
             
             # parameters for CMS mark and lumi stamp

--- a/Tools/python/systematics.py
+++ b/Tools/python/systematics.py
@@ -398,11 +398,11 @@ class Systematic:
                     self.h_map_syst[region] = copy.deepcopy(h_syst)
             
             # Uncertainties
-            #unc = ROOT.TGraphAsymmErrors(h_ratio_den)
-            unc = ROOT.TGraphErrors(h_ratio_den)
+            unc = ROOT.TGraphAsymmErrors(h_ratio_den)
+            #unc = ROOT.TGraphErrors(h_ratio_den)
             #unc = ROOT.TGraph(h_ratio_den)
             
-            setupHist(unc, title, x_title, ratio_title, "electric blue", ratio_y_min, ratio_y_max, True, 3, False)
+            #setupHist(unc, title, x_title, ratio_title, "electric blue", ratio_y_min, ratio_y_max, True, 3, False)
             
             # manually create TGraph
             #nBins = h_ratio_den.GetNbinsX()
@@ -418,9 +418,9 @@ class Systematic:
             unc.SetFillColor(getColorIndex("electric blue"))
             unc.SetFillStyle(3013)
             
-            #unc.SetLineStyle(0)
-            #unc.SetLineWidth(0)
-            #unc.SetMarkerSize(0)
+            unc.SetLineStyle(0)
+            unc.SetLineWidth(0)
+            unc.SetMarkerSize(0)
             
             #unc.SetLineColor(ROOT.kRed)
             #unc.SetLineWidth(3)
@@ -443,8 +443,8 @@ class Systematic:
 
             # --- testing ---
 
-            for n in range(1, h_ratio_den.GetNbinsX() + 1):
-                print "h_ratio_den_{0}_{1}_{2}: bin: {3}, content: {4}, error: {5}".format(era, var, region, n, h_ratio_den.GetBinContent(n), h_ratio_den.GetBinError(n))
+            #for n in range(1, h_ratio_den.GetNbinsX() + 1):
+            #    print "h_ratio_den_{0}_{1}_{2}: bin: {3}, content: {4}, error: {5}".format(era, var, region, n, h_ratio_den.GetBinContent(n), h_ratio_den.GetBinError(n))
             
             #print "TGraphAsymmErrors_{0}: unc.GetN(): {1}".format(era, unc.GetN())
             #for n in range(1, unc.GetN() + 1):

--- a/Tools/python/systematics.py
+++ b/Tools/python/systematics.py
@@ -398,9 +398,9 @@ class Systematic:
                     self.h_map_syst[region] = copy.deepcopy(h_syst)
             
             # Uncertainties
-            unc = ROOT.TGraphAsymmErrors(h_ratio_den)
+            #unc = ROOT.TGraphAsymmErrors(h_ratio_den)
             #unc = ROOT.TGraphErrors(h_ratio_den)
-            #unc = ROOT.TGraph(h_ratio_den)
+            unc = ROOT.TGraph(h_ratio_den)
             
             #setupHist(unc, title, x_title, ratio_title, "electric blue", ratio_y_min, ratio_y_max, True, 3, False)
             
@@ -414,7 +414,7 @@ class Systematic:
             #xVals = np.array(xVals)
             #yVals = np.array(yVals)
             #unc = ROOT.TGraph(nBins, xVals, yVals)
-            
+
             unc.SetFillColor(getColorIndex("electric blue"))
             unc.SetFillStyle(3013)
             
@@ -443,6 +443,7 @@ class Systematic:
 
             # --- testing ---
 
+
             #for n in range(1, h_ratio_den.GetNbinsX() + 1):
             #    print "h_ratio_den_{0}_{1}_{2}: bin: {3}, content: {4}, error: {5}".format(era, var, region, n, h_ratio_den.GetBinContent(n), h_ratio_den.GetBinError(n))
             
@@ -450,9 +451,17 @@ class Systematic:
             #for n in range(1, unc.GetN() + 1):
             #    print "TGraphAsymmErrors_{0}: bin: {1}, x: {2}, y: {3}, x_error: {4}, y_error: {5}".format(era, n, unc.GetPointX(n), unc.GetPointY(n), unc.GetErrorX(n), unc.GetErrorY(n))
             
+            # Error message: AttributeError: 'TGraph' object has no attribute 'GetPointX'
+            
             #print "TGraph_{0}: unc.GetN(): {1}".format(era, unc.GetN())
             #for n in range(1, unc.GetN() + 1):
             #    print "TGraph_{0}: bin: {1}, x: {2}, y: {3}, x_error: {4}, y_error: {5}".format(era, n, unc.GetPointX(n), unc.GetPointY(n), unc.GetErrorX(n), unc.GetErrorY(n))
+            
+            points_x = unc.GetX()
+            points_y = unc.GetY()
+            print "TGraph_{0}: unc.GetN(): {1}".format(era, unc.GetN())
+            for n in range(1, unc.GetN() + 1):
+                print "TGraph_{0}_{1}_{2}: bin: {3}, x: {4}, y: {5}, x_error: {6}, y_error: {7}".format(era, var, region, n, points_x[n-1], points_y[n-1], unc.GetErrorX(n), unc.GetErrorY(n))
             
             # --- draw --- 
             

--- a/Tools/python/tools.py
+++ b/Tools/python/tools.py
@@ -295,7 +295,7 @@ def getConstantMultiplicationError(a, dx):
 def getMultiplicationError(q, x, dx, y, dy):
     # q = x * y 
     # q = x / y 
-    # dq = q * sqrt( (dx/x)^2 + (dy/y)^2) )
+    # dq = q * sqrt( (dx/x)^2 + (dy/y)^2 )
     if x == 0.0 or y == 0.0:
         print "ERROR in getMultiplicationError(): Cannot divide by zero."
         return ERROR_CODE
@@ -304,7 +304,7 @@ def getMultiplicationError(q, x, dx, y, dy):
 def getMultiplicationErrorList(q, x_list, dx_list):
     # q = x * y * ... 
     # q = x / y / ...
-    # dq = q * sqrt( (dx/x)^2 + (dy/y)^2) + ... )
+    # dq = q * sqrt( (dx/x)^2 + (dy/y)^2 + ... )
     if len(x_list) != len(dx_list):
         print "ERROR in getMultiplicationErrorList(): x_list and dx_list do not have the same length."
         return ERROR_CODE

--- a/Tools/python/tools.py
+++ b/Tools/python/tools.py
@@ -254,7 +254,7 @@ def getNormalizedRatio(h_num, h_den):
     return h_ratio_normalized
 
 # setup histogram
-def setupHist(hist, title, x_title, y_title, color, y_min, y_max, adjust=False, lineWidth=5):
+def setupHist(hist, title, x_title, y_title, color, y_min, y_max, adjust=False, lineWidth=5, turnOffStats=True):
     x_axis = hist.GetXaxis()
     y_axis = hist.GetYaxis()
     y_axis.SetRangeUser(y_min, y_max)
@@ -269,9 +269,10 @@ def setupHist(hist, title, x_title, y_title, color, y_min, y_max, adjust=False, 
         y_axis.SetTitleOffset(1.0)
     x_axis.SetTitle(x_title)
     y_axis.SetTitle(y_title)
-    hist.SetStats(ROOT.kFALSE)
     hist.SetLineColor(getColorIndex(color))
     hist.SetLineWidth(lineWidth)
+    if turnOffStats:
+        hist.SetStats(ROOT.kFALSE)
 
 def getAdditionError(dx, dy):
     # q  = x + y


### PR DESCRIPTION
Edits to Z vs Photon double ratio plots.
- add arXiv number
- adjust data point style
- use TGraphErrors to show statistical uncertainties
- fix bugs from TGraph* problems; now errors are properly set